### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*               @canonical/anbox


### PR DESCRIPTION
This sets the default reivewers for everything to the Canonical Anbox team