### PR TITLE
feat(.github): allow manual workflow_dispatch for a specific branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   schedule:
     # execute the action nightly
     - cron: '0 10 * * *'


### PR DESCRIPTION
Add `workflow_dispatch` event, which allows the CI workflow to enable people to select one specific branch without any inputs.