### PR TITLE
chore: add .gitignore to skip artifacts, update node version for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.npm
+node_modules

--- a/js/tests/unit/run-tests.sh
+++ b/js/tests/unit/run-tests.sh
@@ -55,7 +55,7 @@ docker run --rm \
   -v $PWD:/anbox-streaming-sdk-unit-test \
   -e HOME=/anbox-streaming-sdk-unit-test \
   $extra_args \
-  node:17 \
+  node:20 \
   bash -c "cd /anbox-streaming-sdk-unit-test && \
               npm install --include=dev && \
               ./node_modules/.bin/eslint $ESLINT_ARGS anbox-stream-sdk.js && \


### PR DESCRIPTION
- Added `.gitignore` file, so that artifacts created by the `scripts/run-tests.sh` script (`.npm` and `node_modules` folders) are ignored by git.
- Updated node version for the docker image where tests are run, from 17 (EOL since June 1st 2022) to 20 (latest LTS as of today).