### PR TITLE
feat(e2e): add e2e tests for stream disconnect, vhal methods [WD-11812]

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,6 +74,7 @@ jobs:
         set +x
         sudo microbox.amc config set images.auth "bearer:$(sudo cat /var/lib/ubuntu-advantage/private/machine-token.json | jq -r '.resourceTokens[] | select(.type=="anbox-images").token')"
         set -x
+        sudo microbox.amc image add jammy:android13:amd64 jammy:android13:amd64
         sudo microbox.amc image add jammy:aaos13:amd64 jammy:aaos13:amd64
 
     - name: Configure env variables
@@ -81,7 +82,6 @@ jobs:
       run: |
         set -x
         echo "CI=true" >> .env.local
-        echo "ARCHITECTURE=amd64" >> .env.local
         echo "AMS_API_CERTIFICATE=anbox-cloud.crt" >> .env.local
         echo "AMS_API_CERTIFICATE_KEY=anbox-cloud.key" >> .env.local
         echo "AMS_API_URL=$(sudo cat /var/snap/microbox/common/dashboard/config.yaml | grep AMS_API_URL | cut -d ' ' -f2)" >> .env.local

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,7 +74,7 @@ jobs:
         set +x
         sudo microbox.amc config set images.auth "bearer:$(sudo cat /var/lib/ubuntu-advantage/private/machine-token.json | jq -r '.resourceTokens[] | select(.type=="anbox-images").token')"
         set -x
-        sudo microbox.amc image add jammy:android13:amd64 jammy:android13:amd64
+        sudo microbox.amc image add jammy:aaos13:amd64 jammy:aaos13:amd64
 
     - name: Configure env variables
       shell: bash

--- a/js/tests/e2e/fixtures/constants.cjs
+++ b/js/tests/e2e/fixtures/constants.cjs
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-const APP_NAME = "streaming-sdk-e2e-tests";
-const IMAGE_NAME = "jammy:aaos13";
+const AOSP_APP_NAME = "streaming-sdk-e2e-tests_AOSP";
+const AAOS_APP_NAME = "streaming-sdk-e2e-tests_AAOS";
 const DEFAULT_ARCH = "amd64";
 const SERVER_PORT = 2999;
 const BASE_URL = `http://127.0.0.1:${SERVER_PORT}`;
 
-exports.APP_NAME = APP_NAME;
-exports.IMAGE_NAME = IMAGE_NAME;
+exports.AOSP_APP_NAME = AOSP_APP_NAME;
+exports.AAOS_APP_NAME = AAOS_APP_NAME;
 exports.DEFAULT_ARCH = DEFAULT_ARCH;
 exports.SERVER_PORT = SERVER_PORT;
 exports.BASE_URL = BASE_URL;

--- a/js/tests/e2e/fixtures/constants.cjs
+++ b/js/tests/e2e/fixtures/constants.cjs
@@ -17,11 +17,13 @@
  */
 
 const APP_NAME = "streaming-sdk-e2e-tests";
-const IMAGE_NAME = "jammy:android13";
+const IMAGE_NAME = "jammy:aaos13";
+const DEFAULT_ARCH = "amd64";
 const SERVER_PORT = 2999;
 const BASE_URL = `http://127.0.0.1:${SERVER_PORT}`;
 
 exports.APP_NAME = APP_NAME;
 exports.IMAGE_NAME = IMAGE_NAME;
+exports.DEFAULT_ARCH = DEFAULT_ARCH;
 exports.SERVER_PORT = SERVER_PORT;
 exports.BASE_URL = BASE_URL;

--- a/js/tests/e2e/global-teardown.js
+++ b/js/tests/e2e/global-teardown.js
@@ -17,26 +17,38 @@
  */
 
 import { expect } from "@playwright/test";
-import { BASE_URL } from "./fixtures/constants.cjs";
+import {
+  AOSP_APP_NAME,
+  AAOS_APP_NAME,
+  BASE_URL,
+} from "./fixtures/constants.cjs";
 require("dotenv").config({ path: ".env.local" });
 
-const deleteTestSession = async () => {
-  const deleteSessionResponse = await fetch(`${BASE_URL}/session`, {
-    method: "DELETE",
-  });
+const deleteTestSession = async (appName) => {
+  const deleteSessionResponse = await fetch(
+    `${BASE_URL}/session?name=${appName}`,
+    {
+      method: "DELETE",
+    },
+  );
   expect(deleteSessionResponse.status).toBe(200);
 };
 
-const deleteTestApplication = async () => {
-  const deleteAppResponse = await fetch(`${BASE_URL}/application`, {
-    method: "DELETE",
-  });
+const deleteTestApplication = async (appName) => {
+  const deleteAppResponse = await fetch(
+    `${BASE_URL}/application?name=${appName}`,
+    {
+      method: "DELETE",
+    },
+  );
   expect(deleteAppResponse.status).toBe(200);
 };
 
 async function globalTeardown() {
-  await deleteTestSession();
-  await deleteTestApplication();
+  await deleteTestSession(AOSP_APP_NAME);
+  await deleteTestApplication(AOSP_APP_NAME);
+  await deleteTestSession(AAOS_APP_NAME);
+  await deleteTestApplication(AAOS_APP_NAME);
 }
 
 export default globalTeardown;

--- a/js/tests/e2e/index.html
+++ b/js/tests/e2e/index.html
@@ -58,7 +58,7 @@
 
         disconnect() {}
       }
-      var stream, isReady;
+      var stream, isReady, isClosed, vhalPropConfigs;
       window.onload = () => {
         if (sessionId === null) {
           alert("sessionId is missing in the URL");
@@ -76,6 +76,12 @@
           callbacks: {
             ready: () => {
               isReady = true;
+            },
+            vhalReady: () => {
+              vhalPropConfigs = stream.getAllVhalPropConfigs();
+            },
+            done: () => {
+              isClosed = true;
             },
           },
         });

--- a/js/tests/e2e/index.html
+++ b/js/tests/e2e/index.html
@@ -58,7 +58,7 @@
 
         disconnect() {}
       }
-      var stream, isReady, isClosed, vhalPropConfigs;
+      var stream, isReady, isClosed, vhalReady;
       window.onload = () => {
         if (sessionId === null) {
           alert("sessionId is missing in the URL");
@@ -78,7 +78,7 @@
               isReady = true;
             },
             vhalReady: () => {
-              vhalPropConfigs = stream.getAllVhalPropConfigs();
+              vhalReady = true;
             },
             done: () => {
               isClosed = true;

--- a/js/tests/e2e/playwright.config.js
+++ b/js/tests/e2e/playwright.config.js
@@ -24,7 +24,6 @@ export default defineConfig({
   globalSetup: require.resolve("./global-setup"),
   globalTeardown: require.resolve("./global-teardown"),
   testDir: "./tests",
-  reporter: process.env.CI ? "html" : "line",
   /* Maximum time one test can run for. */
   timeout: 60_000,
   expect: {
@@ -43,7 +42,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "html" : "line",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: BASE_URL,

--- a/js/tests/e2e/tests/join.spec.js
+++ b/js/tests/e2e/tests/join.spec.js
@@ -20,6 +20,6 @@ import { test } from "@playwright/test";
 import { joinSession, disconnectStream } from "./shared";
 
 test("join session and disconnect stream", async ({ page }) => {
-  await joinSession(page);
+  await joinSession(page, process.env.AOSP_SESSION_ID);
   await disconnectStream(page);
 });

--- a/js/tests/e2e/tests/shared.js
+++ b/js/tests/e2e/tests/shared.js
@@ -18,8 +18,8 @@
 
 import { expect } from "@playwright/test";
 
-export const joinSession = async (page) => {
-  await page.goto(`/?sessionId=${process.env.SESSION_ID}`);
+export const joinSession = async (page, sessionId) => {
+  await page.goto(`/?sessionId=${sessionId}`);
 
   await expect(page.locator("#anbox-stream").locator("video")).toHaveCount(1);
   await expect(page.locator("#anbox-stream").locator("audio")).toHaveCount(1);

--- a/js/tests/e2e/tests/shared.js
+++ b/js/tests/e2e/tests/shared.js
@@ -16,10 +16,21 @@
  * limitations under the License.
  */
 
-import { test } from "@playwright/test";
-import { joinSession, disconnectStream } from "./shared";
+import { expect } from "@playwright/test";
 
-test("join session and disconnect stream", async ({ page }) => {
-  await joinSession(page);
-  await disconnectStream(page);
-});
+export const joinSession = async (page) => {
+  await page.goto(`/?sessionId=${process.env.SESSION_ID}`);
+
+  await expect(page.locator("#anbox-stream").locator("video")).toHaveCount(1);
+  await expect(page.locator("#anbox-stream").locator("audio")).toHaveCount(1);
+  await page.waitForFunction(() => globalThis.isReady !== undefined, null, {
+    timeout: 20_000,
+  });
+};
+
+export const disconnectStream = async (page) => {
+  await page.evaluate(() => globalThis.stream.disconnect());
+  await page.waitForFunction(() => globalThis.isClosed !== undefined, null, {
+    timeout: 20_000,
+  });
+};

--- a/js/tests/e2e/tests/vhal.spec.js
+++ b/js/tests/e2e/tests/vhal.spec.js
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Anbox Cloud Streaming SDK
+ *
+ * Copyright 2024 Canonical Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from "@playwright/test";
+import { joinSession, disconnectStream } from "./shared";
+
+const VALUES = {
+  287310858: { expected: 0, target: 1 }, // ABS_ACTIVE
+  289475073: { expected: "6,0", target: "6,1" }, // AP_POWER_STATE_REPORT
+  289409539: { expected: 82, target: 100 }, // DISPLAY_BRIGHTNESS
+  291504900: { expected: 101, target: 101.5 }, // ENGINE_OIL_TEMP
+  286261505: { expected: "Toy Vehicle", target: "Foo Bar" }, // INFO_MAKE
+};
+
+const TARGET_VHAL_PROPS = Object.keys(VALUES).map((id) => +id);
+
+test("read VHAL prop configs, get VHAL prop values, set VHAL prop values", async ({
+  page,
+}) => {
+  await joinSession(page);
+
+  await page.waitForFunction(
+    () =>
+      globalThis.vhalPropConfigs !== undefined &&
+      globalThis.vhalPropConfigs.length > 0,
+    null,
+    {
+      timeout: 20_000,
+    },
+  );
+
+  const vhalProperties = await page.evaluate(async (TARGET_VHAL_PROPS) => {
+    const filteredPropConfigs = globalThis.vhalPropConfigs.filter((prop) =>
+      TARGET_VHAL_PROPS.includes(prop.prop),
+    );
+    const vhalProps =
+      await globalThis.stream.getVhalProperties(filteredPropConfigs);
+    return vhalProps;
+  }, TARGET_VHAL_PROPS);
+
+  expect(vhalProperties.length).toBe(TARGET_VHAL_PROPS.length);
+  expect(vhalProperties.some((getResult) => getResult.error)).toBe(false);
+
+  const getSetInput = (propId, targetType, isArray = false) => {
+    const isStringValue = targetType === "string_value";
+    const value = vhalProperties.find((prop) => prop.prop === propId);
+    const currentValue =
+      isArray || isStringValue ? `${value[targetType]}` : value[targetType][0];
+    const setValue =
+      currentValue === VALUES[propId].expected
+        ? VALUES[propId].target
+        : VALUES[propId].expected;
+    return {
+      area_id: 0,
+      prop: propId,
+      [targetType]: isStringValue
+        ? setValue
+        : isArray
+          ? JSON.parse(`[${setValue}]`)
+          : [setValue],
+    };
+  };
+
+  const setInputs = [];
+  setInputs.push(getSetInput(287310858, "int32_values")); // ABS_ACTIVE
+  setInputs.push(getSetInput(289475073, "int32_values", true)); // AP_POWER_STATE_REPORT
+  setInputs.push(getSetInput(289409539, "int32_values")); // DISPLAY_BRIGHTNESS
+  setInputs.push(getSetInput(291504900, "float_values")); // ENGINE_OIL_TEMP
+  setInputs.push(getSetInput(286261505, "string_value")); // INFO_MAKE
+
+  const setProperties = await page.evaluate(async (setInputs) => {
+    const res = await globalThis.stream.setVhalProperties(setInputs);
+    return res;
+  }, setInputs);
+
+  expect(setProperties.length).toBe(TARGET_VHAL_PROPS.length);
+  expect(setProperties.some((setResult) => setResult.error)).toBe(false);
+
+  await disconnectStream(page);
+});

--- a/js/tests/e2e/tests/vhal.spec.js
+++ b/js/tests/e2e/tests/vhal.spec.js
@@ -32,7 +32,7 @@ const TARGET_VHAL_PROPS = Object.keys(VALUES).map((id) => +id);
 test("read VHAL prop configs, get VHAL prop values, set VHAL prop values", async ({
   page,
 }) => {
-  await joinSession(page);
+  await joinSession(page, process.env.AAOS_SESSION_ID);
 
   await page.waitForFunction(
     () =>


### PR DESCRIPTION
# Done

- Determine architecture automatically by querying the `/nodes` endpoint of AMS.
- Add e2e tests for stream disconnect + `done` callback.
- Add e2e tests for VHAL: `vhalReady` callback, `getAllVhalPropConfigs`, `getVhalProperties`, `setVhalProperties` methods.

Until #37 is merged, you can see the test passing [here](https://github.com/lorumic/anbox-streaming-sdk/actions/runs/9676912820/job/26697489529).

Fixes [WD-11812](https://warthogs.atlassian.net/browse/WD-11812)

[WD-11812]: https://warthogs.atlassian.net/browse/WD-11812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ