### PR TITLE
fix(ci) ensure a branch from a forked pr is available in ci

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,11 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        # Fetch all history for all branches and tags
-        fetch-depth: 0
-
-    - name: Check out the source branch
-      run: git checkout ${{ github.event.pull_request.head.ref }}
+        ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
     - name: Store current date and time in output
       id: datetime


### PR DESCRIPTION
 We would previously checkout the canonical repo, but for a PR from a
 fork we need to checkout the fork repo instead.
 WD-12279