### PR TITLE
feat(gh): drop secret use from e2e workflow

### DIFF
--- a/.github/workflows/cache-images.yaml
+++ b/.github/workflows/cache-images.yaml
@@ -1,0 +1,35 @@
+name: Cache Anbox images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *'
+
+jobs:
+  cache-images:
+    name: Cache Anbox images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download images
+      env:
+        IMAGE_SERVER_BUCKET: nightly
+      run: |
+        base_version="$(cat .base_version)"
+        channel="$base_version"/edge
+        image_server_url=https://"${{ secrets.IMAGE_SERVER_AUTH }}"@images.anbox-cloud.io/"$IMAGE_SERVER_BUCKET"/"$channel"
+        item_type=image
+
+        mkdir images
+        for product in android13 aaos13 ; do
+          image_name=jammy:"$product":amd64
+          image_path="$(curl -s "$image_server_url"/streams/v1/images.json | \
+            jq -r "last(.products.\"$image_name\".versions[] | select(.items.\"${item_type}\" != null)).items.\"${item_type}\".path")"
+          image_url="$image_server_url"/"$image_path"
+          curl -s "$image_url" -o images/"$product"_amd64.tar.xz
+        done
+    - name: Cache all images
+      uses: actions/cache/save@v4
+      with:
+        path: images
+        key: anbox-images-amd64

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,39 +2,25 @@ name: E2e tests
 
 on:
   workflow_call:
-    secrets:
-      UBUNTU_PRO_TOKEN:
-        required: true
   workflow_dispatch:
   schedule:
     # execute the action nightly
     - cron: '0 10 * * *'
-  pull_request_target:
-    branches:
-      - '**'
-
+  pull_request:
 defaults:
   run:
     working-directory: js/tests/e2e
 
 jobs:
   e2e:
-    environment: ci-end-to-end
     name: appliance, amd64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
 
     - name: Store current date and time in output
       id: datetime
       run: echo "datetime=$(date -u +'%Y-%m-%dT%H.%M.%SZ')" >> $GITHUB_OUTPUT
-
-    - name: Generate keys
-      run: |
-        set -x
-        openssl req -x509 -newkey rsa:4096 -keyout anbox-cloud.key -out anbox-cloud.crt -days 365 -nodes -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
 
     - name: Install LXD
       uses: canonical/setup-lxd@v0.1.1
@@ -53,28 +39,41 @@ jobs:
     - name: Install Anbox Cloud Appliance
       run: |
         set -x
-        sudo pro attach ${{ secrets.UBUNTU_PRO_TOKEN }}
-        sudo pro enable --access-only anbox-cloud
         sudo apt update
-        sudo apt install -y anbox-modules-dkms-122 linux-modules-extra-$(uname -r)
-        for n in binder_linux anbox_sync virt_wifi ; do sudo modprobe "$n" ; done
-        sudo snap install --channel=1.23/edge anbox-cloud-appliance
+        sudo apt install -y linux-modules-extra-$(uname -r)
+        base_version="$(cat ../../../.base_version)"
+        sudo snap install --channel="$base_version"/edge anbox-cloud-appliance
         sudo anbox-cloud-appliance init --auto
 
-    - name: Configure AMC
+        # FIXME Manually allow access for the current user on the CLI as --auto
+        # does not do this and --preseed is not working with 1.23.0
+        uid="$(id -u)"
+        sudo sed -i "s/allowed-uids.*/allowed-uids: [0, $uid]/g" \
+          /var/snap/anbox-cloud-appliance/common/ams/server/settings.yaml
+        sudo snap restart anbox-cloud-appliance.ams
+
+        amc config set container.security_updates false
+
+
+    - name: Restore cached images
+      uses: actions/cache/restore@v4
+      with:
+        path: images
+        key: anbox-images-amd64
+
+    - name: Import cached images
+      run: |
+        for name in android13 aaos13 ; do
+          amc image add jammy:"$name":amd64 ./images/"$name"_amd64.tar.xz
+        done
+
+    - name: Register trust certificate with AMS
       run: |
         set -x
-        sudo cp anbox-cloud.crt /root/client.crt
-        sudo anbox-cloud-appliance.amc config trust add /root/client.crt
-        sudo anbox-cloud-appliance.amc config set container.security_updates false
-        sudo anbox-cloud-appliance.amc config set images.version_lockstep false
-        sudo anbox-cloud-appliance.amc config set images.url https://images.anbox-cloud.io/stable/
-        # NOTE We need to hide the token here to not accidentially leak credentials
-        set +x
-        sudo anbox-cloud-appliance.amc config set images.auth "bearer:$(sudo cat /var/lib/ubuntu-advantage/private/machine-token.json | jq -r '.resourceTokens[] | select(.type=="anbox-images").token')"
-        set -x
-        sudo anbox-cloud-appliance.amc image add jammy:android13:amd64 jammy:android13:amd64
-        sudo anbox-cloud-appliance.amc image add jammy:aaos13:amd64 jammy:aaos13:amd64
+        openssl req -x509 -newkey rsa:4096 -keyout anbox-cloud.key \
+          -out anbox-cloud.crt -days 365 -nodes \
+          -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
+        amc config trust add ./anbox-cloud.crt
 
     - name: Configure env variables
       shell: bash


### PR DESCRIPTION
We had to do quite a dance to get tests working as the e2e test workflow requires access to the Ubuntu Pro secret. We need to be careful to not allow access to it on a PR from a fork. The approach so far by using the pull_request_target trigger and a dedicated deployment environment with approval was working but far from perfect.

This now implements an alternative which does not require the direct use of the Ubuntu Pro token in the test workflow. Instead we use it to cache images in an independent workflow. The workflow will download all needed images and store them in the Github Action cache under a well known key name. When the e2e workflow now runs it will fetch the images from the cache and load into AMS. The workflow runs every day so we keep the images fresh.

-----

**NOTE** As the cache workflow still has to run the initial execution on the PR itself will fail.