### PR TITLE
Fix the canvas rotation and avoid a busy loop after stopping the streaming when upscaling is enabled

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1135,9 +1135,13 @@ class AnboxStream {
       orientation
     );
 
-    document.getElementById(
-      this._videoID
-    ).style.transform = `rotate(${this._currentRotation}deg)`;
+    let visualElement;
+    if (this._options.experimental.upscaling.enabled) {
+      visualElement = document.getElementById(this._canvasID);
+    } else {
+      visualElement = document.getElementById(this._videoID);
+    }
+    visualElement.style.transform = `rotate(${this._currentRotation}deg)`;
     this._onResize();
     return true;
   }

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3572,6 +3572,7 @@ class AnboxStreamCanvas {
     this._fragmentShader = options.fragmentShader;
 
     // Canvas
+    this._refreshID = 0;
     this._webgl = null;
     this._program = null;
     this._texture = null;
@@ -3626,6 +3627,10 @@ class AnboxStreamCanvas {
 
   stop() {
     window.clearInterval(this._fpsMeasumentlTimerId);
+    if (this._refreshID !== 0) {
+      window.cancelAnimationFrame(this._refreshID);
+      this._refreshID = 0;
+    }
   }
 
   resize(width, height) {
@@ -3664,7 +3669,9 @@ class AnboxStreamCanvas {
   }
 
   _refreshOnInterval(now) {
-    requestAnimationFrame(this._refreshOnInterval.bind(this));
+    this._refreshID = window.requestAnimationFrame(
+      this._refreshOnInterval.bind(this)
+    );
 
     let elapsed = now - this._lastRenderTime;
     if (elapsed > this._fpsInterval) {


### PR DESCRIPTION
- Rotate the canvas rather than video element when upscaling is enabled
- Avoid a busy loop after stopping the streaming when upscaling is enabled 