### PR TITLE
feat(sdk): support multi-pass shaders for the scaling feature

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3585,6 +3585,7 @@ class AnboxStreamCanvas {
 
     // Canvas
     this._refreshID = 0;
+    this._frameCallbackID = 0;
     this._webgl = null;
     this._programs = null;
     this._fbos = {};
@@ -3652,6 +3653,10 @@ class AnboxStreamCanvas {
       window.cancelAnimationFrame(this._refreshID);
       this._refreshID = 0;
     }
+    if (this._frameCallbackID !== 0) {
+      this._video.cancelVideoFrameCallback(this._frameCallbackID);
+      this._frameCallbackID = 0;
+    }
 
     this._webgl.deleteTexture(this._texture);
     this._webgl.deleteBuffer(this._buffers.vertices);
@@ -3697,9 +3702,9 @@ class AnboxStreamCanvas {
   _refreshOnCallback() {
     const refresh = () => {
       this._render(this._webgl);
-      this._video.requestVideoFrameCallback(refresh);
+      this._frameCallbackID = this._video.requestVideoFrameCallback(refresh);
     };
-    this._video.requestVideoFrameCallback(refresh);
+    this._frameCallbackID = this._video.requestVideoFrameCallback(refresh);
   }
 
   _refreshOnInterval(now) {


### PR DESCRIPTION
From the SDK API perspective, the JS SDK supports loading and executing
a single-pass shader for post-processing. However, a few more upscaling
solution is implmented based on multiple passes to achieve a better
result for real-time video streaming processing.
[Anime4K](https://github.com/bloc97/Anime4K) is an example.

With this change, the post-processing procedure can involve multiple
filter passes, allowing users to provide multiple fragment shaders.
Instead of applying a single shader to the texture read from the video
element:

  video texture -> shader -> canvas

The video texture is rendered to a texture attached to a framebuffer
with applied shaders. The process involves swapping textures and
rendering onto another texture until the final filter pass, which is
then applied and rendered onto the canvas.

```
                              | offscreen rendering |
                              | ------------------- |
                              |    texture1 (fbo)   |
  video texture -> shader ->  |        ↓↑           |  -> canvas
                              |      shaders        |
                              |        ↓↑           |
                              |    texture2 (fbo)   |
```
This makes it possible for the integration of complex multi-pass
shaders.