### PR TITLE
Add and integrate Snapdragon Game Super Resolution(SGSR) into js sdk

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,6 +104,19 @@ jobs:
       if: failure()
       run: |
         sudo snap logs -n all anbox-cloud-appliance > appliance.log
+        sudo anbox-cloud-appliance.buginfo > appliance.buginfo
+        for id in $(amc ls --format=csv | cut -d',' -f1) ; do
+          status=$(amc show "$id" --format=json | jq -r .status)
+          if [ "$status" = error ] ; then
+            for log in $(amc show "$id" --format=json | jq -r '.stored_logs[]' | xargs) ; do
+              amc show-log "$id" "$log" |& tee -a "$id"_"$log"
+            done
+          elif [ "$status" = started ] || [ "$status" = running ]; then
+            for name in android anbox ; do
+              timeout 30s amc logs "$id" -t "$name" |& tee -a "$id"_"$name".log
+            done
+          fi
+        done
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
       if: always()
@@ -112,4 +125,6 @@ jobs:
         path: |
           js/tests/e2e/playwright-report/
           js/tests/e2e/*.log
+          appliance.buginfo
+          *.log
         retention-days: 30

--- a/examples/js/Dockerfile
+++ b/examples/js/Dockerfile
@@ -2,9 +2,10 @@ FROM ubuntu:18.04
 
 RUN apt update && apt upgrade -y && apt install -y python3
 
-RUN mkdir /app
+RUN mkdir -p /app/demos
 
-COPY example.html /app
+COPY example.html /app/demos
+COPY sgsr.html /app/demos
 COPY anbox-stream-sdk.js /app
 COPY serve.py /app
 

--- a/examples/js/example.html
+++ b/examples/js/example.html
@@ -8,7 +8,7 @@
 
 <body>
 <script type="module">
-    import {AnboxStream, AnboxStreamGatewayConnector} from './anbox-stream-sdk.js';
+    import {AnboxStream, AnboxStreamGatewayConnector} from '../anbox-stream-sdk.js';
 
     // Connectors will enable communication between the client and the
     // gateway. They can be customized to add an additional layer between

--- a/examples/js/run.sh
+++ b/examples/js/run.sh
@@ -27,4 +27,4 @@ docker build . -t anbox-stream-sdk-example:latest
 id=$(docker run -d --rm -p 8000:8000 anbox-stream-sdk-example:latest)
 echo "$id" > .last_docker_id
 
-echo "INFO: Container up and running, open http://localhost:8000/example.html in your browser ..."
+echo "INFO: Container up and running, open http://localhost:8000/demos in your browser ..."

--- a/examples/js/sgsr.html
+++ b/examples/js/sgsr.html
@@ -8,7 +8,7 @@
 
 <body>
 <script type="module">
-    import {AnboxStream, AnboxStreamGatewayConnector} from './anbox-stream-sdk.js';
+    import {AnboxStream, AnboxStreamGatewayConnector} from '../anbox-stream-sdk.js';
 
     // Connectors will enable communication between the client and the
     // gateway. They can be customized to add an additional layer between

--- a/examples/js/sgsr.html
+++ b/examples/js/sgsr.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <title>Anbox Streaming SDK Example - Enable video upscaling with Snapdragon™ Game Super Resolution(SGSR) </title>
+</head>
+
+<body>
+<script type="module">
+    import {AnboxStream, AnboxStreamGatewayConnector} from './anbox-stream-sdk.js';
+
+    // Connectors will enable communication between the client and the
+    // gateway. They can be customized to add an additional layer between
+    // the client and the gateway in order to add more features (user management,
+    // limits, analytics, etc).
+    // For instance, to add user management, you would create a connector that
+    // would communicate with a service you own, which in turn would talk to the
+    // stream gateway to create an actual streaming session.
+    // The connector would pass that session information to the SDK which takes
+    // care of the rest.
+    const connector = new AnboxStreamGatewayConnector({
+        url: 'https://gateway.url.net',
+        authToken: 'YOUR_AUTH_TOKEN',
+        session: {
+            app: "com.foo.bar"
+        },
+        screen: {
+            width: 1280,
+            height: 720,
+            fps: 25,
+        }
+    });
+
+    // The AnboxStream class takes care of the WebRTC signaling process as
+    // well as the web browser integration (inserting video/audio, controls, inputs, etc)
+    let stream = new AnboxStream({
+        connector: connector,
+        targetElement: "anbox-stream",
+        controls: {
+            keyboard: true
+        },
+        experimental: {
+            upscaling: {
+                enabled: true,
+                fragmentShaders: [
+                  `#version 300 es
+                  /*
+                     Copyright (c) 2023, Qualcomm Innovation Center, Inc. All rights reserved.
+                                 SPDX-License-Identifier: BSD-3-Clause
+
+                           https://github.com/SnapdragonStudios/snapdragon-gsr
+                  */
+
+                  precision mediump float;
+                  precision highp int;
+
+                  ////////////////////////
+                  // USER CONFIGURATION //
+                  ////////////////////////
+
+                  /*
+                  * Operation modes:
+                  * RGBA -> 1
+                  * RGBY -> 3
+                  * LERP -> 4
+                  */
+                  #define OperationMode 1
+                  #define EdgeThreshold 8.0/255.0
+                  #define EdgeSharpness 2.0
+
+                  uniform vec2  uResolution;
+                  in highp vec2 vTextureCoord;
+                  out vec4 outColor;
+
+                  uniform mediump sampler2D uSampler;
+
+                  float fastLanczos2(float x)
+                  {
+                    float wA = x-4.0;
+                    float wB = x*wA-wA;
+                    wA *= wA;
+                    return wB*wA;
+                  }
+
+                  vec2 weightY(float dx, float dy,float c, float std)
+                  {
+                    float x = ((dx*dx)+(dy* dy))* 0.55 + clamp(abs(c)*std, 0.0, 1.0);
+                    float w = fastLanczos2(x);
+                    return vec2(w, w * c);
+                  }
+
+                  // Workaround the textureGather function which is unavailable in WebGL2
+                  vec4 texelGather(sampler2D tex, vec2 uv, vec2 texelSize, int channel) {
+                    vec4 t0 = texture(tex, uv + texelSize * vec2(-0.5, -0.5));
+                    vec4 t1 = texture(tex, uv + texelSize * vec2( 0.5, -0.5));
+                    vec4 t2 = texture(tex, uv + texelSize * vec2(-0.5,  0.5));
+                    vec4 t3 = texture(tex, uv + texelSize * vec2( 0.5,  0.5));
+
+                    float c0 = (channel == 0) ? t0.r : (channel == 1) ? t0.g : (channel == 2) ? t0.b : t0.a;
+                    float c1 = (channel == 0) ? t1.r : (channel == 1) ? t1.g : (channel == 2) ? t1.b : t1.a;
+                    float c2 = (channel == 0) ? t2.r : (channel == 1) ? t2.g : (channel == 2) ? t2.b : t2.a;
+                    float c3 = (channel == 0) ? t3.r : (channel == 1) ? t3.g : (channel == 2) ? t3.b : t3.a;
+
+                    return vec4(c0, c1, c2, c3);
+                  }
+
+                  void main()
+                  {
+                    highp vec4 ViewportInfo[1];
+                    int mode = OperationMode;
+                    float edgeThreshold = EdgeThreshold;
+                    float edgeSharpness = EdgeSharpness;
+
+                    ViewportInfo[0] = vec4(1.0 / uResolution.x, 1.0 / uResolution.y,
+                                           uResolution.x, uResolution.y);
+
+                    vec4 color;
+                    if(mode == 1)
+                      color.xyz = textureLod(uSampler, vTextureCoord.xy, 0.0).xyz;
+                    else
+                      color.xyzw = textureLod(uSampler, vTextureCoord.xy, 0.0).xyzw;
+
+                    /*
+                    highp float xCenter;
+                    xCenter = abs(vTextureCoord.x+-0.5);
+                    highp float yCenter;
+                    yCenter = abs(vTextureCoord.y+-0.5);
+                    */
+
+                    //todo: config the SR region based on needs
+                    //if ( mode!=4 && xCenter*xCenter+yCenter*yCenter<=0.4 * 0.4)
+                    if (mode!=4)
+                    {
+                      highp vec2 imgCoord = ((vTextureCoord.xy*ViewportInfo[0].zw)+vec2(-0.5,0.5));
+                      highp vec2 imgCoordPixel = floor(imgCoord);
+                      highp vec2 coord = (imgCoordPixel*ViewportInfo[0].xy);
+                      vec2 pl = (imgCoord+(-imgCoordPixel));
+
+                      vec4 left = texelGather(uSampler, coord, ViewportInfo[0].xy, mode);
+
+                      float edgeVote = abs(left.z - left.y) + abs(color[mode] - left.y)  + abs(color[mode] - left.z) ;
+                      if(edgeVote > edgeThreshold)
+                      {
+                        coord.x += ViewportInfo[0].x;
+
+                        vec4 right = texelGather(uSampler,coord + vec2(ViewportInfo[0].x, 0.0), ViewportInfo[0].xy, mode);
+                        vec4 upDown;
+                        upDown.xy = texelGather(uSampler,coord + vec2(0.0, -ViewportInfo[0].y), ViewportInfo[0].xy, mode).wz;
+                        upDown.zw = texelGather(uSampler,coord+ vec2(0.0, ViewportInfo[0].y), ViewportInfo[0].xy, mode).yx;
+
+                        float mean = (left.y+left.z+right.x+right.w)*0.25;
+                        left = left - vec4(mean);
+                        right = right - vec4(mean);
+                        upDown = upDown - vec4(mean);
+                        color.w =color[mode] - mean;
+
+                        float sum = (((((abs(left.x)+abs(left.y))+abs(left.z))+abs(left.w))+(((abs(right.x)+abs(right.y))+abs(right.z))+abs(right.w)))+(((abs(upDown.x)+abs(upDown.y))+abs(upDown.z))+abs(upDown.w)));
+                        float std = 2.181818/sum;
+
+                        vec2 aWY = weightY(pl.x, pl.y+1.0, upDown.x,std);
+                        aWY += weightY(pl.x-1.0, pl.y+1.0, upDown.y,std);
+                        aWY += weightY(pl.x-1.0, pl.y-2.0, upDown.z,std);
+                        aWY += weightY(pl.x, pl.y-2.0, upDown.w,std);
+                        aWY += weightY(pl.x+1.0, pl.y-1.0, left.x,std);
+                        aWY += weightY(pl.x, pl.y-1.0, left.y,std);
+                        aWY += weightY(pl.x, pl.y, left.z,std);
+                        aWY += weightY(pl.x+1.0, pl.y, left.w,std);
+                        aWY += weightY(pl.x-1.0, pl.y-1.0, right.x,std);
+                        aWY += weightY(pl.x-2.0, pl.y-1.0, right.y,std);
+                        aWY += weightY(pl.x-2.0, pl.y, right.z,std);
+                        aWY += weightY(pl.x-1.0, pl.y, right.w,std);
+
+                        float finalY = aWY.y/aWY.x;
+
+                        float maxY = max(max(left.y,left.z),max(right.x,right.w));
+                        float minY = min(min(left.y,left.z),min(right.x,right.w));
+                        finalY = clamp(edgeSharpness*finalY, minY, maxY);
+
+                        float deltaY = finalY -color.w;
+
+                        //smooth high contrast input
+                        deltaY = clamp(deltaY, -23.0 / 255.0, 23.0 / 255.0);
+
+                        color.x = clamp((color.x+deltaY),0.0,1.0);
+                        color.y = clamp((color.y+deltaY),0.0,1.0);
+                        color.z = clamp((color.z+deltaY),0.0,1.0);
+                      }
+                    }
+
+                    color.w = 1.0;  //assume alpha channel is not used
+                    outColor = color;
+                  }`
+                ]
+            }
+        },
+        callbacks: {
+            error: error => {
+                window.alert("AnboxStream failed: " + error.message);
+            },
+            requestCameraAccess: () => {
+                return window.confirm("Anbox Cloud requires to access the camera device")
+            }
+        }
+    });
+
+    window.startStream = () => {
+        stream.connect();
+    }
+
+</script>
+    <h1>Anbox Streaming SDK Example - Enable video upscaling with
+     <a href="https://github.com/SnapdragonStudios/snapdragon-gsr" target="_blank"> Snapdragon™ Game Super Resolution (SGSR) </a>
+    </h1>
+    <button onclick="window.startStream()">Start</button>
+    <div id="anbox-stream" style="width: 100vw; height: 100vh;"></div>
+    <footer style="margin-top: 20px; font-size: 0.8em;">
+        <p>Snapdragon™ is a trademark of Qualcomm Incorporated. This project is not affiliated with or endorsed by Qualcomm.</p>
+    </footer>
+</body>
+</html>

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -566,8 +566,7 @@ class AnboxStream {
   _hasWebGLSupported() {
     try {
       const canvas = document.createElement("canvas");
-      const ctx =
-        canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+      const ctx = canvas.getContext("webgl2");
       if (this._nullOrUndef(ctx)) return false;
     } catch (e) {
       return false;
@@ -3599,7 +3598,7 @@ class AnboxStreamCanvas {
     canvas.style.position = "absolute";
     canvas.id = this._canvasID;
 
-    const gl = canvas.getContext("webgl");
+    const gl = canvas.getContext("webgl2");
     const programs = this._loadPrograms(gl);
     if (this._nullOrUndef(programs) || programs.length === 0) {
       throw newError(

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2036,12 +2036,11 @@ const _imeEventType = {
 
 const _maxTouchPointSize = 10;
 
-const _vertexShaderSource = `
+const _vertexShaderSource = `#version 300 es
 precision mediump float;
-
-attribute vec2 aVertexPos;
-attribute vec2 aTextureCoord;
-varying highp vec2 vTextureCoord;
+in vec2 aVertexPos;
+in vec2 aTextureCoord;
+out highp vec2 vTextureCoord;
 
 void main()
 {
@@ -2050,19 +2049,20 @@ void main()
 }
 `;
 
-const _fragShaderSource = `
+const _fragShaderSource = `#version 300 es
 precision mediump float;
-uniform vec2 uResolution;
 uniform sampler2D uSampler;
-varying highp vec2 vTextureCoord;
+in highp vec2 vTextureCoord;
+out vec4 outColor;
 
 void main()
 {
-    gl_FragColor = texture2D(uSampler, vTextureCoord);
+  outColor = texture(uSampler, vTextureCoord);
 }
 `;
 
-const _fsrShaderSource = `/*
+const _fsrShaderSource = `#version 300 es
+/*
   Original:https://www.shadertoy.com/view/stXSWB
   by goingdigital
 
@@ -2082,7 +2082,8 @@ precision mediump float;
 uniform float sharpness;
 uniform vec2  uResolution;
 uniform sampler2D uSampler;
-varying highp vec2 vTextureCoord;
+in highp vec2 vTextureCoord;
+out vec4 outColor;
 
 /***** RCAS *****/
 #define FSR_RCAS_LIMIT (0.25-(1.0/16.0))
@@ -2155,7 +2156,7 @@ vec3 FsrRcasF(
 }
 
 vec4 FsrRcasLoadF(vec2 p) {
-    return texture2D(uSampler, p/uResolution.xy);
+    return texture(uSampler, p/uResolution.xy);
 }
 
 void main()
@@ -2166,8 +2167,7 @@ void main()
     FsrRcasCon(con,sharpness);
 
     vec3 col = FsrRcasF(vTextureCoord, con);
-
-    gl_FragColor = vec4(col, 1.0);
+    outColor = vec4(col, 1.0);
 }
 `;
 

--- a/scripts/streaming-sdk-files.allowlist
+++ b/scripts/streaming-sdk-files.allowlist
@@ -196,6 +196,7 @@ examples/js/run.sh
 examples/js/Dockerfile
 examples/js/README.md
 examples/js/example.html
+examples/js/sgsr.html
 examples/js/serve.py
 js/anbox-stream-sdk.js
 js/README.md


### PR DESCRIPTION
Snapdragon™ Game Super Resolution(SGSR), which integrates upscaling
and sharpening in one single GPU shader pass. The algorithm uses a
12-tap Lanczos-like scaling filter and adaptive sharpening filter,
which presents smooth images and sharp edges. For more details:
    
     https://github.com/SnapdragonStudios/snapdragon-gsr
    
This change adds and integrates SGSR, this single GPU shader pass
into the streaming js sdk, and usd by default for the time being.
    
NOTE: for now, FSR is still kept in the source for reference.
In the end, we will choose the best upscaling algorithm from all
available options after benchmarking and comparing performance and
quality, and only ship the best one in the streaming SDK.
