### PR TITLE
fix(e2e): add small delay between text input and snapshot check

### DIFF
--- a/js/tests/e2e/tests/visual.spec.js
+++ b/js/tests/e2e/tests/visual.spec.js
@@ -44,6 +44,8 @@ const openSearchBar = async (page) => {
 
 const typeSearch = async (page, text) => {
   await page.keyboard.type(text);
+  // Wait 1s (text input)
+  await page.waitForTimeout(1000);
   await expect(page).toHaveScreenshot("text-input.png", OPTIONS);
 };
 


### PR DESCRIPTION
Added a 1s timeout after text input and before checking the snapshot, to reduce the flakiness of the keyboard input visual test.