### PR TITLE
Update doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Refer to the following examples to explore advanced usage scenarios and best pra
 
 * [Simple Android Webview Streaming](examples/android/webview_streaming) - An Android example that embeds WebView integrated with the JS SDK for video streaming.
 * [Enhanced Android Webview Streaming](examples/android/enhanced_webview_streaming) - An Android example that embeds AnboxWebView for text input handling enhancement for a hybrid application.
-* [Out of Band](examples/android/out_of_band_v2) - An Android example demonstrating the usage of [out of band data](https://anbox-cloud.io/docs/howto/stream/oob-data#oob-v2) feature which exchanges data between the Android application running in the Anbox container and a streaming client.
+* [Out of Band](examples/android/out_of_band_v2) - An Android example demonstrating the usage of [out of band data](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/stream/exchange-oob-data/#oob-v2) feature which exchanges data between the Android application running in the Anbox container and a streaming client.
 * [JavaScript-based Streaming Example](examples/js) - A web application utilizes the JS SDK for video streaming.
 
 ## Contributing

--- a/android/anbox_streaming_sdk/README.md
+++ b/android/anbox_streaming_sdk/README.md
@@ -17,5 +17,5 @@ flavors in the build/outputs/aar/ directory of the project.
 
 ## Integrate the AAR library into your project
 
-See the [development documentation](https://anbox-cloud.io/docs/howto/stream/client-side-keyboard)
+See the [development documentation](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/stream/integrate-virtual-keyboard/)
 for how to integrate the AAR library into your project.

--- a/examples/android/out_of_band_v2/README.md
+++ b/examples/android/out_of_band_v2/README.md
@@ -1,6 +1,6 @@
 # Anbox Cloud - Out of Band Data v2
 
-An Android application that demonstrates how to use [out of band data v2](https://anbox-cloud.io/docs/howto/stream/oob-data#oob-v2)
+An Android application that demonstrates how to use [out of band data v2](https://documentation.ubuntu.com/anbox-cloud/en/latest/howto/stream/exchange-oob-data/#oob-v2)
 to exchange data between an Android application and a WebRTC client.
 
 **Note:** to install the app as a system app in the Android container,

--- a/js/tests/unit/sdk.test.js
+++ b/js/tests/unit/sdk.test.js
@@ -152,7 +152,7 @@ test("Video container with no size specified", () => {
   expect(() => new AnboxStream(options)).not.toThrow();
   expect(console.error).toHaveBeenCalledWith(
     expect.stringContaining(
-      "AnboxStream: video container element misses size. Please see https://anbox-cloud.io/docs/howto/stream/web-client"
+      "AnboxStream: video container element misses size. Please see https://documentation.ubuntu.com/anbox-cloud/en/latest/tutorial/stream-client"
     )
   );
   global.console.error.mockRestore();


### PR DESCRIPTION
Updating documentation links. The link for streaming tutorial will become live once https://github.com/canonical/anbox-cloud-docs/pull/205 is merged