### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Anbox Cloud security policy
+
+Learn about our [release and support policy](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/release-notes/release-notes/#release-and-support-policy) for the nature of our releases and versions.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability, follow the steps outlined below to report it:
+
+1. Do not publicly disclose the vulnerability before discussing it with us.
+2. Report a bug at https://bugs.launchpad.net/anbox-cloud
+
+    **Important**: Remember to set the information type to *Private Security*. You will see a field with the text *This bug contains information that is:*
+3. Provide detailed information about the vulnerability, including:
+   - A description of the vulnerability
+   - Steps to reproduce the issue
+   - Potential impact and affected versions
+   - Suggested mitigation, if possible
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.
+
+The Anbox Cloud team will be notified of the issue and review the vulnerability. We may reach out to you for further information or clarification if needed. 
+If the issue is confirmed as a valid security vulnerability, we will assign a CVE and coordinate the release of the fix. We also document them as [security notices](https://documentation.ubuntu.com/anbox-cloud/en/latest/reference/security-notices/).


### PR DESCRIPTION
Adding security policy for this repository. The content is already reviewed at  https://github.com/canonical/anbox-cloud-docs/pull/229