### PR TITLE
fix(e2e): set session offline to avoid results in search widget

### DIFF
--- a/js/tests/e2e/package.json
+++ b/js/tests/e2e/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node server.js",
     "test:coverage": "rm -rf coverage ; PW_TEST_HTML_REPORT_OPEN='never' npx playwright test",
-    "test-report-coverage": "cp ../unit/coverage/coverage-final.json coverage/ && sed -i 's|\/anbox-streaming-sdk-unit-test\/||g' coverage/coverage-final.json && cd ../.. && BASE_PATH=$(pwd) && sed -i \"s|anbox-stream-sdk.js|$BASE_PATH\/anbox-stream-sdk.js|g\" tests/e2e/coverage/*.json && nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir $BASE_PATH/tests/e2e/coverage --report-dir $BASE_PATH/tests/e2e/coverage/combined-report/js ; mv tests/e2e/coverage/combined-report/js/cobertura-coverage.xml tests/e2e/coverage/combined-report/cobertura-coverage-js.xml"
+    "test-report-coverage": "cp ../unit/coverage/coverage-final.json coverage/ && sed -i 's|/anbox-streaming-sdk-unit-test/||g' coverage/coverage-final.json && cd ../.. && BASE_PATH=$(pwd) && sed -i \"s|anbox-stream-sdk.js|$BASE_PATH/anbox-stream-sdk.js|g\" tests/e2e/coverage/*.json && nyc report --reporter html --reporter cobertura --reporter text-summary --temp-dir $BASE_PATH/tests/e2e/coverage --report-dir $BASE_PATH/tests/e2e/coverage/combined-report/js ; mv tests/e2e/coverage/combined-report/js/cobertura-coverage.xml tests/e2e/coverage/combined-report/cobertura-coverage-js.xml"
   },
   "author": "indore-team@launchpad.net",
   "license": "Proprietary",

--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -32,6 +32,7 @@ const {
 } = require("./fixtures/constants.cjs");
 
 const app = express();
+app.use(express.json());
 app.listen(SERVER_PORT);
 
 const amsAgent = new https.Agent({
@@ -271,6 +272,31 @@ app.post("/join", (req, res) => {
       {
         headers: asgHeaders,
         httpsAgent: asgAgent,
+      },
+    )
+    .then((response) => {
+      res.send(response.data);
+    })
+    .catch((error) => {
+      res.status(500).send(error);
+    });
+});
+
+app.post("/execCommand", (req, res) => {
+  const instanceId = req.body.instanceId;
+  const command = req.body.command;
+  const payload = {
+    command: [command],
+    height: 0,
+    interactive: true,
+    width: 0,
+  };
+  axios
+    .post(
+      `${process.env.AMS_API_URL}/1.0/instances/${instanceId}/exec`,
+      payload,
+      {
+        httpsAgent: amsAgent,
       },
     )
     .then((response) => {


### PR DESCRIPTION
Fix for the failure in the "Run code quality scan" job run [here](https://github.com/canonical/anbox-streaming-sdk/actions/runs/12274448590/job/34247382351).

We are getting unexpected search results when testing the visual output of sending keyboard input to the stream (see screenshots below). It should be possible to prevent that by putting the Android instance offline.

- Expected:

![image](https://github.com/user-attachments/assets/d52611f1-641a-4e12-b009-18503b97682f)

- Received:

![image](https://github.com/user-attachments/assets/b181333b-2546-4801-af5e-a180b1ca39ce)