### PR TITLE
Fix TICS report workflow, revert `execCommand` addition, set rate limits

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -18,10 +18,7 @@ concurrency:
 jobs:
   tics-scan:
     name: Run TICS quality scan
-    if: ${{ github.repository_owner == 'canonical' }}
-    runs-on: [self-hosted, linux, X64, noble, large]
-    env:
-      DEBIAN_FRONTEND: noninteractive
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
     - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4

--- a/js/tests/e2e/global-setup.js
+++ b/js/tests/e2e/global-setup.js
@@ -64,19 +64,6 @@ const waitForInstanceRunning = async (page, appName) => {
   return false;
 };
 
-const setSessionOffline = async (instanceId) => {
-  const command =
-    "anbox-shell ip link set wlan0 down && anbox-shell ip link set eth0 down";
-  const execCommandResponse = await fetch(`${BASE_URL}/execCommand`, {
-    method: "POST",
-    body: JSON.stringify({ instanceId, command }),
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  expect(execCommandResponse.status).toBe(200);
-};
-
 const createTestInstance = async (appName) => {
   const createInstanceResponse = await fetch(
     `${BASE_URL}/instance?appName=${appName}`,
@@ -155,8 +142,6 @@ const setupSessionFor = async (page, appName) => {
       `No running instance for the target test application: ${appName}`,
     );
   }
-  const instanceId = instance.id;
-  await setSessionOffline(instanceId);
   const sessionId = instance.tags
     .find((tag) => tag.startsWith("session="))
     .split("session=")[1];

--- a/js/tests/e2e/package-lock.json
+++ b/js/tests/e2e/package-lock.json
@@ -13,6 +13,7 @@
         "compressing": "^1.10.1",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.4.1",
         "yaml": "^2.4.2"
       },
       "devDependencies": {
@@ -1672,6 +1673,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/js/tests/e2e/package.json
+++ b/js/tests/e2e/package.json
@@ -28,6 +28,7 @@
     "compressing": "^1.10.1",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.4.1",
     "yaml": "^2.4.2"
   }
 }

--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -32,7 +32,6 @@ const {
 } = require("./fixtures/constants.cjs");
 
 const app = express();
-app.use(express.json());
 app.listen(SERVER_PORT);
 
 const amsAgent = new https.Agent({
@@ -272,31 +271,6 @@ app.post("/join", (req, res) => {
       {
         headers: asgHeaders,
         httpsAgent: asgAgent,
-      },
-    )
-    .then((response) => {
-      res.send(response.data);
-    })
-    .catch((error) => {
-      res.status(500).send(error);
-    });
-});
-
-app.post("/execCommand", (req, res) => {
-  const instanceId = req.body.instanceId;
-  const command = req.body.command;
-  const payload = {
-    command: [command],
-    height: 0,
-    interactive: true,
-    width: 0,
-  };
-  axios
-    .post(
-      `${process.env.AMS_API_URL}/1.0/instances/${instanceId}/exec`,
-      payload,
-      {
-        httpsAgent: amsAgent,
       },
     )
     .then((response) => {

--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -33,11 +33,11 @@ const {
 
 const app = express();
 
-// set up rate limiter: maximum of five requests per minute
-var RateLimit = require("express-rate-limit");
-var limiter = RateLimit({
+// set up rate limiter: maximum of ten requests per minute
+const RateLimit = require("express-rate-limit");
+const limiter = RateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // max 100 requests per windowMs
+  max: 200, // max 200 requests per windowMs
 });
 
 // apply rate limiter to all requests

--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -32,6 +32,17 @@ const {
 } = require("./fixtures/constants.cjs");
 
 const app = express();
+
+// set up rate limiter: maximum of five requests per minute
+var RateLimit = require("express-rate-limit");
+var limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
+
 app.listen(SERVER_PORT);
 
 const amsAgent = new https.Agent({


### PR DESCRIPTION
- Reverted the addition of an `execCommand` endpoint to reduce CodeQL warnings.
- Set rate limits to reduce CodeQL warnings.
- Use GH runners instead of self-hosted ones for the TICS workflow.