### PR TITLE
fix(gamepad): stop polling in game manager to avoid redundant events

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1728,6 +1728,9 @@ class AnboxStream {
     if (!this._options.controls.gamepad) return;
     let gamepads = navigator.getGamepads ? navigator.getGamepads() : [];
     if (gamepads.length > 0) {
+      if (this._gamepadManager) {
+        this._gamepadManager.stopPolling();
+      }
       this._gamepadManager = new _gamepadEventManager(
         this._sendInputEvent.bind(this),
       );


### PR DESCRIPTION
## Done

- Added a check before the initialisation of a `_gamepadEventManager` instance. If it was already initialised before, it should `stopPolling` before initialising a new one, to avoid receiving redundant gamepad events.