### PR TITLE
fix: resolve TICS compiler warning in _onError

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2319,7 +2319,8 @@ class AnboxWebRTCManager {
     this._debugEnabled = options.debug;
     this._apiVersionInUse = options.apiVersion;
 
-    this._onError = () => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onError = (msg, code) => {};
     this._onReady = () => {};
     this._onClose = () => {};
     this._onMicRequested = () => false;


### PR DESCRIPTION
## Done

Fixed TICS warning: expected 0 arguments but received 2, violating JSC_WRONG_NUMBER_OF_PARAMS.

## JIRA / Launchpad bug

Fixes #[WD-17751](https://warthogs.atlassian.net/browse/WD-17751)



[WD-17751]: https://warthogs.atlassian.net/browse/WD-17751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ