### PR TITLE
fix: resolve TICS inexistent property warning

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2817,14 +2817,16 @@ class AnboxWebRTCManager {
     this._controlChan.onerror = (err) => {
       if (this._controlChan !== null) {
         let code = ANBOX_STREAM_SDK_ERROR_WEBRTC_CONTROL_FAILED;
-        switch (err.error.sctpCauseCode) {
-          case SCP_CAUSE_CODE_USER_INITIATED_ABORT:
-            code = ANBOX_STREAM_SDK_ERROR_WEBRTC_DISCONNECTED;
-            break;
-          default:
-            break;
+        if (err.error) {
+          switch (err.error.sctpCauseCode) {
+            case SCP_CAUSE_CODE_USER_INITIATED_ABORT:
+              code = ANBOX_STREAM_SDK_ERROR_WEBRTC_DISCONNECTED;
+              break;
+            default:
+              break;
+          }
+          this._onError(`error on control channel: ${err.error.message}`, code);
         }
-        this._onError(`error on control channel: ${err.error.message}`, code);
       }
     };
     this._controlChan.onclose = () => this._log("control channel is closed");


### PR DESCRIPTION
## Done

- Fixed TICS warning: Property 'error' does not exist on type 'Event', violating JSC_INEXISTENT_PROPERTY.

## JIRA / Launchpad bug

Fixes #[WD-17751](https://warthogs.atlassian.net/browse/WD-17751)


[WD-17751]: https://warthogs.atlassian.net/browse/WD-17751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ