### PR TITLE
fix: TICS wrong number of params compiler warnings

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2825,16 +2825,14 @@ class AnboxWebRTCManager {
     this._controlChan.onerror = (err) => {
       if (this._controlChan !== null) {
         let code = ANBOX_STREAM_SDK_ERROR_WEBRTC_CONTROL_FAILED;
-        if (err.error) {
-          switch (err.error.sctpCauseCode) {
-            case SCP_CAUSE_CODE_USER_INITIATED_ABORT:
-              code = ANBOX_STREAM_SDK_ERROR_WEBRTC_DISCONNECTED;
-              break;
-            default:
-              break;
-          }
-          this._onError(`error on control channel: ${err.error.message}`, code);
+        switch (err?.error?.sctpCauseCode) {
+          case SCP_CAUSE_CODE_USER_INITIATED_ABORT:
+            code = ANBOX_STREAM_SDK_ERROR_WEBRTC_DISCONNECTED;
+            break;
+          default:
+            break;
         }
+        this._onError(`error on control channel: ${err?.error?.message}`, code);
       }
     };
     this._controlChan.onclose = () => this._log("control channel is closed");

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2321,16 +2321,23 @@ class AnboxWebRTCManager {
 
     // eslint-disable-next-line no-unused-vars
     this._onError = (msg, code) => {};
-    this._onReady = () => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onReady = (videoStream, audioStream) => {};
     this._onClose = () => {};
     this._onMicRequested = () => false;
     this._onCameraRequested = () => false;
-    this._onMessage = () => {};
-    this._onStatsUpdated = () => {};
-    this._onIMEStateChanged = () => {};
-    this._onVhalPropConfigsReceived = () => {};
-    this._onVhalGetAnswerReceived = () => {};
-    this._onVhalSetAnswerReceived = () => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onMessage = (type, data) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onStatsUpdated = (stats) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onIMEStateChanged = (isChanged) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onVhalPropConfigsReceived = (data) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onVhalGetAnswerReceived = (data) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onVhalSetAnswerReceived = (data) => {};
     this._onControlChannelOpen = () => {};
   }
 
@@ -3122,8 +3129,7 @@ class AnboxWebRTCManager {
 
       default:
         this._log(
-          "received ICE connection state change",
-          this._pc.iceConnectionState,
+          `received ICE connection state change: ${this._pc.iceConnectionState}`,
         );
         break;
     }


### PR DESCRIPTION
## Done

- Fixes multiple compiler warnings violating the rule JSC_WRONG_NUMBER_OF_PARAMS 
- Fixes a single occurrence of the JSC_INEXISTENT_PROPERTY violation

## JIRA / Launchpad bug

Fixes #[WD-17751](https://warthogs.atlassian.net/browse/WD-17751)


[WD-17751]: https://warthogs.atlassian.net/browse/WD-17751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ