### PR TITLE
Do not abort streaming on non-fatal errors

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1749,9 +1749,15 @@ class AnboxStream {
     return obj === null || obj === undefined;
   }
 
+  _isFatalError(code) {
+    return code !== ANBOX_STREAM_SDK_ERROR_USER_MEDIA;
+  }
+
   _stopStreamingOnError(msg, code) {
     this._options.callbacks.error(newError(msg, code));
-    this._stopStreaming();
+    if (this._isFatalError(code)) {
+      this._stopStreaming();
+    }
   }
 
   _IMEStateChanged(visible) {
@@ -2356,11 +2362,11 @@ class AnboxWebRTCManager {
 
   /**
    * @callback onWebRTCError
-   * @param error {string} Error message
+   * @param error {Error} Error object containing the message and code
    */
   /**
    * Called when the video track has been successfully created
-   * @param callback {onWebRTCError} Callback invoked with error message
+   * @param callback {onWebRTCError} Callback invoked with error object
    */
   onError(callback) {
     this._onError = (msg, code) => {

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2372,7 +2372,6 @@ class AnboxWebRTCManager {
     this._onError = (msg, code) => {
       if (this._debugEnabled) console.error(msg);
       callback(newError(msg, code));
-      this.stop();
     };
   }
 

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2454,7 +2454,7 @@ class AnboxWebRTCManager {
    */
   start(session) {
     if (session.websocket === undefined || session.websocket.length === 0) {
-      throw this._onError(
+      this._onError(
         "connector did not return any signaling information",
         ANBOX_STREAM_SDK_ERROR_SIGNALING_FAILED,
       );

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 for component in js ; do
-    ( cd "$component"; ./run-tests.sh )
+    ( cd "$component"; ./run-tests.sh $@ )
 done


### PR DESCRIPTION
## Done

If a client accidentally enables the camera while their device is
not equipped with one, it triggers the `ANBOX_STREAM_SDK_ERROR_USER_MEDIA`
error. However, this is not a fatal error and make less sense to
abort the streaming when no camera is found.
    
In such cases, we simply report the error to the end user and
prevent the streaming SDK from handling it.

## QA

Run added unit test

## JIRA / Launchpad bug

AC-3082
https://bugs.launchpad.net/anbox-cloud/+bug/2077598

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?