### PR TITLE
Release workflow changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      with:
-        # to avoid shadow clone which would impact the version generation
-        # See `scripts/gen-version.sh`
-        fetch-depth: "0"
 
     - name: Build
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,17 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Create tag
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
-      with:
-        script: |
-          await github.rest.git.createRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: 'refs/tags/${{ inputs.tag_name }}',
-            sha: context.sha
-          })
-
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
@@ -41,7 +30,7 @@ jobs:
 
     - name: Build
       run: |
-        ./scripts/build.sh --create-tarball
+        ./scripts/build.sh --create-tarball --version=${{ inputs.tag_name }}
 
     - name: Run tests
       run: |
@@ -50,5 +39,5 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
       with:
-        files: anbox-streaming-sdk_${{ steps.get-version.outputs.version }}.zip
-        tag_name: ${{ steps.get-version.outputs.version }}
+        files: anbox-streaming-sdk_${{ inputs.tag_name }}.zip
+        tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
       tag_name:
         description: 'Tag name for the release'
         required: true
+      target_commitish:
+        description: |
+          Target commitish (see GH API) for tag creation.
+          Can be empty - it will default to the head of the branch it is run from.
+        required: false
 
 # To publish assets to on GitHub release pages
 permissions:
@@ -32,3 +37,4 @@ jobs:
       with:
         files: anbox-streaming-sdk_${{ inputs.tag_name }}.zip
         tag_name: ${{ inputs.tag_name }}
+        target_commitish: ${{ inputs.target_commitish }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,11 +23,6 @@ jobs:
         # See `scripts/gen-version.sh`
         fetch-depth: "0"
 
-    - name: Get version
-      id: get-version
-      run: |
-        echo "version=$(./scripts/gen-version.sh)" >> $GITHUB_OUTPUT
-
     - name: Build
       run: |
         ./scripts/build.sh --create-tarball --version=${{ inputs.tag_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,5 @@ jobs:
         files: anbox-streaming-sdk_${{ inputs.tag_name }}.zip
         tag_name: ${{ inputs.tag_name }}
         target_commitish: ${{ inputs.target_commitish }}
+        body: |
+          See https://documentation.ubuntu.com/anbox-cloud/reference/release-notes/${{ inputs.tag_name }}/ for more information.


### PR DESCRIPTION
## Done

Small changes to the release workflow: instead of tagging, and then creating the release and testing, we instead depend first build and test before tagging. We're thus not using the version generation script anymore, and instead rely on the tag name. In practice, this shouldn't change anything: if we're based on a tag, the generation script just returns the tag name.

This should avoid creating a tag, and then failing to publish the release as the tests or build failed (for instance).

Also add a way to specify a different commit than the branch head. This should give more flexibility in choosing the commit for the release, to ensure it is the aligned with the one used by the dashboard (as this is the version that was tested the most).

Last, this fills the body of the release with a link to the release notes in our docs website.

## QA

N/A

## JIRA / Launchpad bug

Contributes to AC-3134

## Documentation

Release documentation will be updated accordingly.