### PR TITLE
Respect verticalAlignment setting for video top offset

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1202,6 +1202,7 @@ class AnboxStream {
       this._streamCanvas.resize(video.videoWidth, video.videoHeight);
     }
 
+    let offsetTop;
     switch (this._currentRotation) {
       case 0:
       case 180:
@@ -1209,12 +1210,13 @@ class AnboxStream {
         visualElement.style.width = playerWidth.toString() + "px";
         if (this._options.verticalAlignment === "top") {
           visualElement.style.top = "0";
+          offsetTop = 0;
         } else if (this._options.verticalAlignment === "bottom") {
           visualElement.style.bottom = "0";
+          offsetTop = container.clientHeight - playerHeight;
         } else {
-          visualElement.style.top = `${Math.round(
-            container.clientHeight / 2 - playerHeight / 2,
-          )}px`;
+          offsetTop = Math.round(container.clientHeight / 2 - playerHeight / 2);
+          visualElement.style.top = `${offsetTop}px`;
         }
         visualElement.style.left = `${Math.round(
           container.clientWidth / 2 - playerWidth / 2,
@@ -1226,9 +1228,12 @@ class AnboxStream {
         visualElement.style.width = playerHeight.toString() + "px";
         if (this._options.verticalAlignment === "top") {
           visualElement.style.top = "0";
+          offsetTop = 0;
         } else if (this._options.verticalAlignment === "bottom") {
           visualElement.style.bottom = "0";
+          offsetTop = container.clientHeight - playerHeight;
         } else {
+          offsetTop = Math.round(container.clientHeight / 2 - playerHeight / 2);
           visualElement.style.top = `${Math.round(
             container.clientHeight / 2 - playerWidth / 2,
           )}px`;
@@ -1252,8 +1257,7 @@ class AnboxStream {
     }
 
     // The visual offset is always derived from the same formula, no matter the orientation.
-    const offsetTop = Math.round(container.clientHeight / 2 - playerHeight / 2); // + getPadding('top')
-    const offsetLeft = Math.round(container.clientWidth / 2 - playerWidth / 2); // + getPadding('left')
+    const offsetLeft = Math.round(container.clientWidth / 2 - playerWidth / 2);
 
     this._dimensions = {
       videoHeight: videoHeight,

--- a/js/tests/unit/sdk.test.js
+++ b/js/tests/unit/sdk.test.js
@@ -467,3 +467,38 @@ test("do no stop streaming on non fatal errors", (done) => {
   expect(() => stream.disconnect()).not.toThrow();
   expect(stream._webrtcManager.stop).toHaveBeenCalledTimes(1);
 });
+
+test("player respects the vertical aligment settings", () => {
+  const verticalAlignments = ["top", "center", "bottom"];
+
+  for (const alignment of verticalAlignments) {
+    let opts = { ...sdkOptions };
+    opts.verticalAlignment = alignment;
+    const stream = new AnboxStream(opts);
+
+    const video = document.createElement("video");
+    video.id = stream._videoID;
+    video.__defineGetter__("videoWidth", () => 1000);
+    video.__defineGetter__("videoHeight", () => 500);
+
+    const container = document.getElementById(sdkOptions.targetElement);
+    container.__defineGetter__("clientWidth", () => 2000);
+    container.__defineGetter__("clientHeight", () => 2000);
+    container.appendChild(video);
+
+    stream._onResize();
+    let dimensions = stream._dimensions;
+    expect(dimensions.playerWidth).toEqual(2000);
+    expect(dimensions.playerHeight).toEqual(1000);
+
+    let expectedOffsetTop;
+    if (alignment === "top") {
+      expectedOffsetTop = 0;
+    } else if (alignment === "center") {
+      expectedOffsetTop = 500;
+    } else if (alignment === "bottom") {
+      expectedOffsetTop = 1000;
+    }
+    expect(dimensions.playerOffsetTop).toEqual(expectedOffsetTop);
+  }
+});


### PR DESCRIPTION
With the introduction of the verticalAlignment setting, the video's top 
offset should be adjusted accordingly. Otherwise, input event positions
may be misaligned.

Fixes https://bugs.launchpad.net/anbox-cloud/+bug/2093904

