### PR TITLE
Group digest updates together in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     "schedule:earlyMondays",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
-    "helpers:pinGitHubActionDigests",
+    "helpers:pinGitHubActionDigestsToSemver",
     "group:allNonMajor",
     "group:allDigest"
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
     "helpers:pinGitHubActionDigests",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    "group:allDigest"
   ]
 }


### PR DESCRIPTION
## Done

To decrease the amount of dependency update PRs we get from renovate, tell it to group digest updates together (e.g. GitHub actions).

Also add full semver information to GH digests, see https://github.com/renovatebot/renovate/discussions/21901.

## QA

Check next renovate run.

## JIRA / Launchpad bug

N/A

## Documentation

N/A