### PR TITLE
chore: pin anbox-cloud-github-action to git rev

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,7 +55,7 @@ jobs:
         echo "base_version=$(cat .base_version)" >> "$GITHUB_OUTPUT"
 
     - name: Setup Anbox Cloud
-      uses: canonical/anbox-cloud-github-action@main
+      uses: canonical/anbox-cloud-github-action@ef6a5352c3be13f788dfc1939e510e5fa73ebc83
       with:
         channel: ${{ steps.config.outputs.base_version }}/edge
 


### PR DESCRIPTION
## Done

We should never reference a branch or tag but an explicit git sha266 rev.

## QA

n/a

## JIRA / Launchpad bug

n/a

## Documentation

n/a