### PR TITLE
chore: use global TICSAUTHTOKEN

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -111,5 +111,5 @@ jobs:
         mode: qserver
         project: anbox-streaming-sdk
         viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
-        ticsAuthToken: ${{ secrets.TICS_AUTH_TOKEN }}
+        ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
         installTics: true


### PR DESCRIPTION
## Done

There is now a secret present at the org level named TICSAUTHTOKEN so we no longer need to have our own.

## QA

Run TICS workflow once merged

## JIRA / Launchpad bug

https://warthogs.atlassian.net/browse/AC-3245

## Documentation

n/a