### PR TITLE
fix(gh): add pull-requests write permission to branching workflow

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   branch:


### PR DESCRIPTION


## Done

* This change allows the branching workflow to use github token to open a pull request on the repository itself.

