### PR TITLE
1.26 - Checkout whole history to generate version correctly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      with:
+        fetch-depth: 0
 
     - name: Build
       run: |


### PR DESCRIPTION
## Done

Checkout the whole history of the repository to ensure the generate version script works as intended - 1.26 backport.

## QA

Run Publish SDK workflow.

## JIRA / Launchpad bug

N/A

## Documentation

N/A