### PR TITLE
1.26 - Fix publish v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: stable
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,6 @@ jobs:
       with:
         files: anbox-streaming-sdk_${{ inputs.tag_name }}.zip
         tag_name: ${{ inputs.tag_name }}
-        target_commitish: ${{ inputs.target_commitish }}
+        target_commitish: ${{ inputs.target_commitish || github.ref }}
         body: |
           See https://documentation.ubuntu.com/anbox-cloud/reference/release-notes/${{ inputs.tag_name }}/ for more information.


### PR DESCRIPTION
## Done

Add stable environment to publish SDK and fix commitish selection.

## QA

Run Publish SDK

## JIRA / Launchpad bug

N/A

## Documentation

N/A