### PR TITLE
Update disk size in e2e tests

### DIFF
--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -146,7 +146,7 @@ app.post("/application", async (req, res) => {
     resources: {
       cpus: 4,
       memory: "3GB",
-      "disk-size": "3GB",
+      "disk-size": "4GB",
     },
   };
   const manifestBuffer = Buffer.from(yaml.stringify(manifestJson));


### PR DESCRIPTION
## Done

Update the minimum disk size in e2e tests to 4GB, following a change in AMS.

## QA

Run e2e tests.

## JIRA / Launchpad bug

N/A

## Documentation

N/A