### PR TITLE
Revert "fix(e2e): update minimum disk size to 4GB"

### DIFF
--- a/js/tests/e2e/server.js
+++ b/js/tests/e2e/server.js
@@ -146,7 +146,7 @@ app.post("/application", async (req, res) => {
     resources: {
       cpus: 4,
       memory: "3GB",
-      "disk-size": "4GB",
+      "disk-size": "3GB",
     },
   };
   const manifestBuffer = Buffer.from(yaml.stringify(manifestJson));


### PR DESCRIPTION
## Done

We are reverting to using ZFS by default, so we should go back to a 3GB default disk size.

Note: this PR will fail until we get a new AMS version.

## QA

Run e2e tests.

## JIRA / Launchpad bug

Contributes to [AC-3511](https://warthogs.atlassian.net/browse/AC-3511)

## Documentation

N/A

[AC-3511]: https://warthogs.atlassian.net/browse/AC-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ