### PR TITLE
Group GitHub actions update together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,19 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "group:allNonMajor",
     "group:allDigest"
+  ],
+  "packageRules": [
+    {
+      "groupName": "GitHub actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "digest",
+        "patch",
+        "minor",
+        "major"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Done

Group GitHub actions together to make it easier to bring in updates.

As we have pending updates to the Android parts which require manual work, grouping only GH actions together will help us in actually getting them up to date.

## QA

N/A

## JIRA / Launchpad bug

N/A

## Documentation

N/A