### PR TITLE
chore: bump base version to 1.29.3

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of Anbox Cloud Streaming SDK
  *
- * Version: 1.29.2
+ * Version: 1.29.3
  *
  * Copyright 2021 Canonical Ltd.
  *


### PR DESCRIPTION
bump base version to 1.29.3