### PR TITLE
Add the missing back key

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2161,6 +2161,7 @@ const _keyScancodes = {
   Volumedown: 89,
   Volumeup: 90,
   Power: 91,
+  Back: 92,
 };
 
 const _modifierEnum = {

--- a/js/tests/unit/input-events.test.js
+++ b/js/tests/unit/input-events.test.js
@@ -1081,3 +1081,26 @@ test("sendInputKey returns false and logs an error for unknown key", () => {
   expect(console.error).toHaveBeenCalledWith('Unknown input key: "UnknownKey"');
   expect(mockFn.mock.calls.length).toEqual(0);
 });
+
+test("common Android keys are present with correct scancodes", () => {
+  let stream = setupStream(sdkOptions);
+  stream._webrtcManager.sendControlMessage = jest.fn();
+
+  const androidKeys = [
+    { name: "Home", code: 74 },
+    { name: "Volumedown", code: 89 },
+    { name: "Volumeup", code: 90 },
+    { name: "Power", code: 91 },
+    { name: "Back", code: 92 },
+  ];
+
+  for (const { name, code } of androidKeys) {
+    stream._webrtcManager.sendControlMessage.mockClear();
+    const result = stream.sendInputKey(name);
+    expect(result).toEqual(true);
+    expect(stream._webrtcManager.sendControlMessage).toHaveBeenCalledWith(
+      "input::key",
+      { code, pressed: true },
+    );
+  }
+});


### PR DESCRIPTION
## Done

This enables the simulation of Back key events sent from the WebRTC
client and being forwarded correctly to Android system over the control
data channel.

NOTE: Anbox WebRTC platform already supports the Back key on the backend.
This change implements the corresponding client-side support to complete
the e2e integration.

## QA

1. Open up an application E.g. settings
2. Fire the following key event from a stream client 

```
stream = new AnboxStream({...})
stream.sendInputKey("Back");
```
3. Ensure that the active application is pushed to the background

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A:no, it doesn't