### PR TITLE
Log control messages when experimental.debug is enabled

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3210,6 +3210,8 @@ class AnboxWebRTCManager {
   }
 
   _onControlMessageReceived(event) {
+    this._log("control message received: " + event.data);
+
     const msg = JSON.parse(event.data);
     switch (msg.type) {
       case "open-camera":

--- a/js/tests/unit/callbacks.test.js
+++ b/js/tests/unit/callbacks.test.js
@@ -298,3 +298,28 @@ test("custom message callback is called", (done) => {
   event = { data: "foo_text" };
   chans[0].onmessage(event);
 });
+
+test("do not log control message data when debug is disabled", () => {
+  sdkOptions.callbacks = {};
+  sdkOptions.experimental = { debug: false };
+  const stream = new AnboxStream(sdkOptions);
+  const consoleInfoSpy = jest.spyOn(console, "info");
+
+  const msg = JSON.stringify({ type: "action", data: "test" });
+  stream._webrtcManager._onControlMessageReceived({ data: msg });
+
+  expect(consoleInfoSpy).not.toHaveBeenCalled();
+  consoleInfoSpy.mockRestore();
+});
+
+test("log control message data when debug is enabled", () => {
+  sdkOptions.callbacks = {};
+  sdkOptions.experimental = { debug: true };
+  const stream = new AnboxStream(sdkOptions);
+  const logSpy = jest.spyOn(stream._webrtcManager, "_log");
+
+  const msg = JSON.stringify({ type: "action", data: "test" });
+  stream._webrtcManager._onControlMessageReceived({ data: msg });
+
+  expect(logSpy).toHaveBeenCalledWith("control message received: " + msg);
+});


### PR DESCRIPTION
## Done

This helps in troubleshooting issues by confirming if specific control 
messages, such as vhal-prop-configs, are received by the webrtc client 
as this message is essential for the dashboard to display the VHAL panel.

## QA

1. Initialize AnboxStream object with
```
        stream = new AnboxStream({ 
          ...
          ...
          experimental: {
            debug: true
          },
        }
```
2. Verify that all control messages are correctly logged in the console.

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: no, it doesn't