### PR TITLE
Log full ICE candidate

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3189,9 +3189,12 @@ class AnboxWebRTCManager {
   }
 
   _addIceCandidate(msg) {
-    this._log("got RTC candidate");
+    const candidate = atob(msg.candidate);
+    this._log(
+      `got RTC candidate: ${candidate} (sdpMid=${msg.sdpMid}, sdpMLineIndex=${msg.sdpMLineIndex})`,
+    );
     this._pc.addIceCandidate({
-      candidate: atob(msg.candidate),
+      candidate: candidate,
       sdpMLineIndex: msg.sdpMLineIndex,
       sdpMid: msg.sdpMid,
     });

--- a/js/tests/e2e/package-lock.json
+++ b/js/tests/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.22.0",
       "license": "Proprietary",
       "dependencies": {
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "compressing": "1.10.5",
         "dotenv": "16.4.7",
         "express": "4.22.2",
@@ -881,12 +881,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -5147,11 +5147,11 @@
       }
     },
     "axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "requires": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/js/tests/e2e/package.json
+++ b/js/tests/e2e/package.json
@@ -24,7 +24,7 @@
     "v8-to-istanbul": "9.3.0"
   },
   "dependencies": {
-    "axios": "1.15.2",
+    "axios": "1.16.0",
     "compressing": "1.10.5",
     "dotenv": "16.4.7",
     "express": "4.22.2",


### PR DESCRIPTION
## Done

Include candidate string in the log along with sdpMid and sdpMLineIndex, 
so that the candidate type, address, and associated media section are visible
when `options.experimental.debug` is set to true.

## QA

Ensure the ICE candidate is printed out in the console when
`options.experimental.debug` option is set to true.

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: no, it doesn't