### PR TITLE
Multi displays support

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -158,10 +158,33 @@ class AnboxStream {
       this._detectUnsupportedBrowser();
 
     this._id = Math.random().toString(36).substr(2, 9);
-    this._containerID = options.targetElement;
+
+    // _containerID is the primary display container. It's reserved for
+    // in single display.
+    this._containerID = options.targetElement || null;
+    // _containerIDs is an array of video container IDs used to attach input listeners
+    // to multiple video tracks.
+    this._containerIDs = this._containerID ? {0: this._containerID} : {};
+
     this._videoID = "anbox-stream-video-" + this._id;
     this._audioID = "anbox-stream-audio-" + this._id;
     this._canvasID = "anbox-stream-canvas-" + this._id;
+    this._multiDisplayActive = false;
+
+    this._pendingVideoTracks = {};
+    this._pendingReadyCount = 0;
+
+    this._displayStates = this._containerID
+      ? {
+          0: {
+            dimensions: null,
+            activeTouchPointers: [],
+            pointerIdsMapper: {},
+            primaryTouchId: 0,
+            pointersOutofBounds: {},
+          },
+        }
+      : {};
 
     // WebRTC
     this._webrtcManager = new AnboxWebRTCManager({
@@ -248,16 +271,45 @@ class AnboxStream {
 
     // Control options
     this._modifierState = 0;
-    this._dimensions = null;
     this._gamepadManager = null;
     this._streamCanvas = null;
 
     this._originalOrientation = null;
     this._currentRotationDegrees = 0;
-    this._primaryTouchId = 0;
-    this._pointersOutofBounds = {};
-    this._activeTouchPointers = [];
-    this._pointerIdsMapper = {};
+    // Legacy aliases forward to primary display state for any code that was not
+    // yet updated to use the per-display state bag.
+    Object.defineProperty(this, "_dimensions", {
+      get: () => this._displayStates[0].dimensions,
+      set: (v) => {
+        this._displayStates[0].dimensions = v;
+      },
+    });
+    Object.defineProperty(this, "_primaryTouchId", {
+      get: () => this._displayStates[0].primaryTouchId,
+      set: (v) => {
+        this._displayStates[0].primaryTouchId = v;
+      },
+    });
+    Object.defineProperty(this, "_pointersOutofBounds", {
+      get: () => this._displayStates[0].pointersOutofBounds,
+      set: (v) => {
+        this._displayStates[0].pointersOutofBounds = v;
+      },
+    });
+    Object.defineProperty(this, "_activeTouchPointers", {
+      get: () => this._displayStates[0].activeTouchPointers,
+      set: (v) => {
+        this._displayStates[0].activeTouchPointers = v;
+      },
+    });
+    Object.defineProperty(this, "_pointerIdsMapper", {
+      get: () => this._displayStates[0].pointerIdsMapper,
+      set: (v) => {
+        this._displayStates[0].pointerIdsMapper = v;
+      },
+    });
+
+    this._displayEventListeners = [];
 
     this.controls = {
       touch: {
@@ -1010,17 +1062,38 @@ class AnboxStream {
     window.addEventListener("resize", this._onResize);
 
     if (this._options.controls.mouse) {
-      const container = document.getElementById(this._containerID);
-      if (container) {
-        for (const controlName in this.controls.touch)
-          container.addEventListener(
-            controlName,
-            this.controls.touch[controlName],
-          );
-      }
+      // Register primary display input listeners on its container.
+      const container = document.getElementById(this._containerIDs[0]);
+      if (container) this._registerInputHandlers(0, container);
     }
 
     this.captureKeyboard();
+  }
+
+  _registerInputHandlers(displayId, container) {
+    if (!this._options.controls.mouse) return;
+
+    const handlers = {
+      pointermove: (e) => this._onPointerEvent(e, displayId),
+      pointerdown: (e) => this._onPointerEvent(e, displayId),
+      pointerup: (e) => this._onPointerEvent(e, displayId),
+      pointercancel: (e) => this._onPointerEvent(e, displayId),
+      mousewheel: (e) => this._onMouseWheel(e, displayId),
+    };
+
+    for (const [name, fn] of Object.entries(handlers))
+      container.addEventListener(name, fn);
+
+    this._displayEventListeners[displayId] = { container, handlers };
+  }
+
+  _unregisterInputHandlers(displayId) {
+    const entry = this._displayEventListeners[displayId];
+    if (!entry) return;
+    const { container, handlers } = entry;
+    for (const [name, fn] of Object.entries(handlers))
+      container.removeEventListener(name, fn);
+    delete this._displayEventListeners[displayId];
   }
 
   /**
@@ -1148,17 +1221,9 @@ class AnboxStream {
   _unregisterControls() {
     window.removeEventListener("resize", this._onResize);
 
-    // Removing the video container should automatically remove all event listeners
-    // but this is dependant on the garbage collector, so we manually do it if we can
     if (this._options.controls.mouse) {
-      const container = document.getElementById(this._containerID);
-      if (container) {
-        for (const controlName in this.controls.touch)
-          container.removeEventListener(
-            controlName,
-            this.controls.touch[controlName],
-          );
-      }
+      for (const i of Object.keys(this._containerIDs).map(Number))
+        this._unregisterInputHandlers(i);
     }
 
     this.releaseKeyboard();
@@ -1299,7 +1364,28 @@ class AnboxStream {
     if (video === null || container === null) return;
     if (video.videoWidth === 0 || video.videoHeight === 0) return;
 
-    // We calculate the distance to the closest window border while keeping aspect ratio intact.
+    // In multi-display mode, recompute all attached displays so that any
+    // layout changes (new display added, window resize) are reflected.
+    if (this._multiDisplayActive) {
+      this._computeMultiDisplayDimensions(video, container, 0);
+      const extraIds = Object.keys(this._containerIDs).map(Number).filter(i => i > 0);
+      for (const i of extraIds) {
+        const secId = `${this._videoID}-display-${i}`;
+        const secVideo = document.getElementById(secId);
+        const secContainer = document.getElementById(this._containerIDs[i]);
+        if (
+          secVideo &&
+          secContainer &&
+          secVideo.videoWidth > 0 &&
+          secVideo.videoHeight > 0
+        ) {
+          this._computeMultiDisplayDimensions(secVideo, secContainer, i);
+        }
+      }
+      return;
+    }
+
+    // Single-display mode
     let videoHeight = video.videoHeight;
     let videoWidth = video.videoWidth;
 
@@ -1400,7 +1486,7 @@ class AnboxStream {
     // The visual offset is always derived from the same formula, no matter the orientation.
     const offsetLeft = Math.round(container.clientWidth / 2 - playerWidth / 2);
 
-    this._dimensions = {
+    this._displayStates[0].dimensions = {
       videoHeight: videoHeight,
       videoWidth: videoWidth,
       scalePercentage: resizePercentage,
@@ -1408,6 +1494,52 @@ class AnboxStream {
       playerWidth: playerWidth,
       playerOffsetLeft: offsetLeft,
       playerOffsetTop: offsetTop,
+    };
+  }
+
+  // Compute dimensions for a single display's video element inside its container
+  // for multi-display mode.
+  _computeMultiDisplayDimensions(video, container, displayId) {
+    const cRect = container.getBoundingClientRect();
+    const cellWidth = cRect.width;
+    const cellHeight = cRect.height;
+
+    const videoWidth = video.videoWidth;
+    const videoHeight = video.videoHeight;
+
+    // Compute the largest size that fits the video aspect ratio inside the cell.
+    const scale = Math.min(cellWidth / videoWidth, cellHeight / videoHeight);
+    const renderedWidth = Math.round(videoWidth * scale);
+    const renderedHeight = Math.round(videoHeight * scale);
+    const offsetLeft = Math.round((cellWidth - renderedWidth) / 2);
+    const offsetTop = Math.round((cellHeight - renderedHeight) / 2);
+
+    // Size and position the video element to exactly match the rendered content.
+    video.style.width = renderedWidth + "px";
+    video.style.height = renderedHeight + "px";
+    video.style.left = offsetLeft + "px";
+    video.style.top = offsetTop + "px";
+
+    if (!(displayId in this._displayStates)) {
+      this._displayStates[displayId] = {
+        dimensions: null,
+        activeTouchPointers: [],
+        pointerIdsMapper: {},
+        primaryTouchId: 0,
+        pointersOutofBounds: {},
+      };
+    }
+
+    // The playerOffset is 0 because the video element is already sized to the
+    // rendered content.
+    this._displayStates[displayId].dimensions = {
+      videoHeight: videoHeight,
+      videoWidth: videoWidth,
+      scalePercentage: scale,
+      playerHeight: renderedHeight,
+      playerWidth: renderedWidth,
+      playerOffsetLeft: 0,
+      playerOffsetTop: 0,
     };
   }
 
@@ -1476,74 +1608,115 @@ class AnboxStream {
 
   /**
    * Returns true if a pointer event (move or click) was emitted outside the video
-   * boundaries
+   * boundaries of the given display.
+   * @param {object} event
+   * @param {number} displayId
    * @returns {boolean}
    * @private
    */
-  _isPointerEventOutOfBounds(event) {
+  _isPointerEventOutOfBounds(event, displayId) {
+    const dim = this._displayStates[displayId].dimensions;
     return (
       event.clientX < 0 ||
-      event.clientX > this._dimensions.playerWidth ||
+      event.clientX > dim.playerWidth ||
       event.clientY < 0 ||
-      event.clientY > this._dimensions.playerHeight
+      event.clientY > dim.playerHeight
     );
   }
 
   /**
    * PointerEvents coordinates are relative to the document. This method
    * removes the various offsets so the (0,0) coordinate corresponds to
-   * to the top left corner of the video element
+   * the top left corner of the video content for the given display.
+   *
+   * Uses _containerIDs[displayId] as the reference element so that in
+   * dynamic single-container mode, coordinates are computed against the
+   * correct cell div (not the outer container), even after the grid layout
+   * changes. Scale and offsets are recomputed live to avoid stale values
+   * when containers resize (e.g. secondary displays appearing).
    * @param event
+   * @param {number} displayId
    * @private
    */
-  _adjustPointerCoordsToVideoBoundaries(event) {
-    const container = document.getElementById(this._containerID);
-    if (!container) return false;
+  _adjustPointerCoordsToVideoBoundaries(event, displayId) {
+    const videoId = displayId === 0
+      ? this._videoID
+      : `${this._videoID}-display-${displayId}`;
+    const video = document.getElementById(videoId);
+    if (!video || !video.videoWidth || !video.videoHeight) return false;
 
-    const dim = this._dimensions;
-    if (!dim) return false;
+    const vRect = video.getBoundingClientRect();
+    if (vRect.width === 0 || vRect.height === 0) return false;
 
-    const cRect = container.getBoundingClientRect();
-    event.clientX = Math.round(
-      event.clientX - cRect.left - dim.playerOffsetLeft,
+    const scale = Math.min(
+      vRect.width / video.videoWidth,
+      vRect.height / video.videoHeight,
     );
-    event.clientY = Math.round(event.clientY - cRect.top - dim.playerOffsetTop);
+    const renderedWidth = Math.round(video.videoWidth * scale);
+    const renderedHeight = Math.round(video.videoHeight * scale);
+    const contentOffsetX = Math.round((vRect.width - renderedWidth) / 2);
+    const contentOffsetY = Math.round((vRect.height - renderedHeight) / 2);
+
+    event.clientX = Math.round(event.clientX - vRect.left - contentOffsetX);
+    event.clientY = Math.round(event.clientY - vRect.top - contentOffsetY);
+
+    // Keep cached dimensions in sync for
+    //  1. _isPointerEventOutOfBounds
+    //  2. _translateLocalCoordsToRemoteCoords
+    const state = this._displayStates[displayId];
+    if (state) {
+      if (!state.dimensions) {
+        state.dimensions = {
+          videoWidth: video.videoWidth,
+          videoHeight: video.videoHeight,
+          scalePercentage: scale,
+          playerWidth: renderedWidth,
+          playerHeight: renderedHeight,
+          playerOffsetLeft: contentOffsetX,
+          playerOffsetTop: contentOffsetY,
+        };
+      } else {
+        state.dimensions.scalePercentage = scale;
+        state.dimensions.playerWidth = renderedWidth;
+        state.dimensions.playerHeight = renderedHeight;
+        state.dimensions.playerOffsetLeft = contentOffsetX;
+        state.dimensions.playerOffsetTop = contentOffsetY;
+      }
+    }
+
     return true;
   }
 
   /**
    * The video displayed on the client might be stretched to fit its display.
-   * Because of this, local coordinates may not match the remote container.
-   * This method translates local coordinates so they fit the remote container
+   * This method translates local coordinates so they fit the remote container.
    * @param event {PointerEvent}
+   * @param {number} displayId
    * @private
    */
-  _translateLocalCoordsToRemoteCoords(event) {
+  _translateLocalCoordsToRemoteCoords(event, displayId) {
+    const dim = this._displayStates[displayId].dimensions;
+
     if (event.pointerType === "touch") {
       const pos = this._convertTouchInput(event.clientX, event.clientY);
       event.clientX = pos.x;
       event.clientY = pos.y;
     }
 
-    // The video might be scaled up or down, so we translate the coordinates to take this
-    // scaling into account
-    event.clientX /= this._dimensions.scalePercentage;
-    event.clientY /= this._dimensions.scalePercentage;
+    event.clientX /= dim.scalePercentage;
+    event.clientY /= dim.scalePercentage;
 
-    event.movementX = Math.round(
-      event.movementX / this._dimensions.scalePercentage,
-    );
-    event.movementY = Math.round(
-      event.movementY / this._dimensions.scalePercentage,
-    );
+    event.movementX = Math.round(event.movementX / dim.scalePercentage);
+    event.movementY = Math.round(event.movementY / dim.scalePercentage);
   }
 
   /**
-   * onPointerEvent is called when a mouse or touch input is fired
-   * @param pointerEvent
+   * onPointerEvent is called when a mouse or touch input is fired.
+   * @param pointerEvent {PointerEvent}
+   * @param {number} [displayId=0] Index of the display that received the event.
    * @private
    */
-  _onPointerEvent(pointerEvent) {
+  _onPointerEvent(pointerEvent, displayId = 0) {
     pointerEvent.preventDefault();
 
     // If pointer lock is used but not active dismiss all events until the
@@ -1554,6 +1727,9 @@ class AnboxStream {
     )
       return;
 
+    const state = this._displayStates[displayId];
+    if (!state) return;
+
     // The pointerEvent.pointerId increments every time when a new touch point
     // is pressed(can be used to differentiate the touch point from others,
     // However the downside of this is that it can not be used as the MT slot
@@ -1563,11 +1739,11 @@ class AnboxStream {
     // correct MT slot event forwarding to Android container.
     const pointerId = Math.abs(pointerEvent.pointerId);
     if (pointerEvent.isPrimary) {
-      this._primaryTouchId = pointerId;
+      state.primaryTouchId = pointerId;
     }
 
-    const ori_pointerId = pointerId - this._primaryTouchId;
-    const new_pointerId = this._findPointerId(ori_pointerId);
+    const ori_pointerId = pointerId - state.primaryTouchId;
+    const new_pointerId = this._findPointerId(ori_pointerId, state);
 
     // JS events are read-only, so we create a clone of the event that
     // we can modify down the road
@@ -1585,9 +1761,9 @@ class AnboxStream {
     if (this._options.controls.emulateTouch) event.pointerType = "touch";
 
     // Transform pointer coordinates so (0,0) corresponds to the top left corner of the video
-    if (!this._adjustPointerCoordsToVideoBoundaries(event)) return;
+    if (!this._adjustPointerCoordsToVideoBoundaries(event, displayId)) return;
 
-    if (this._isPointerEventOutOfBounds(event)) {
+    if (this._isPointerEventOutOfBounds(event, displayId)) {
       // In either of the following cases, ignore the events when
       // they are out of bounds.
       // a) If the feature `emulatePoitnerEvent` is disabled,
@@ -1596,7 +1772,7 @@ class AnboxStream {
       if (!this._options.experimental.emulatePointerEvent) return;
 
       if (
-        event.pointerId in this._pointersOutofBounds &&
+        event.pointerId in state.pointersOutofBounds &&
         event.type != "pointerup"
       )
         return;
@@ -1605,21 +1781,22 @@ class AnboxStream {
       // is out of bounds.
       event.type = "pointerup";
 
+      const dim = state.dimensions;
       if (event.clientX < 0) {
         event.clientX = 0;
-      } else if (event.clientX > this._dimensions.playerWidth) {
-        event.clientX = this._dimensions.playerWidth;
+      } else if (event.clientX > dim.playerWidth) {
+        event.clientX = dim.playerWidth;
       }
       if (event.clientY < 0) {
         event.clientY = 0;
-      } else if (event.clientY > this._dimensions.playerHeight) {
-        event.clientY = this._dimensions.playerHeight;
+      } else if (event.clientY > dim.playerHeight) {
+        event.clientY = dim.playerHeight;
       }
 
-      this._pointersOutofBounds[event.pointerId] = true;
+      state.pointersOutofBounds[event.pointerId] = true;
     } else if (
       this._options.experimental.emulatePointerEvent &&
-      event.pointerId in this._pointersOutofBounds
+      event.pointerId in state.pointersOutofBounds
     ) {
       // Replace the type of the event with 'pointerdown' if it comes
       // to 'pointermove' event after the event with the type 'pointerup'
@@ -1632,24 +1809,26 @@ class AnboxStream {
         event.type = "pointerdown";
       }
 
-      delete this._pointersOutofBounds[event.pointerId];
+      delete state.pointersOutofBounds[event.pointerId];
     }
 
     // Apply video scaling and rotation to the coordinates
-    this._translateLocalCoordsToRemoteCoords(event);
+    this._translateLocalCoordsToRemoteCoords(event, displayId);
 
     if (event.type === "pointermove" && event.pointerType === "touch") {
-      const index = this._activeTouchPointers.indexOf(event.pointerId);
+      const index = state.activeTouchPointers.indexOf(event.pointerId);
       if (index === -1) return;
       this._sendInputEvent("touch-move", {
         id: event.pointerId,
         x: event.clientX,
         y: event.clientY,
+        display_id: displayId,
       });
     } else if (event.type === "pointermove" && event.pointerType === "mouse") {
       var e = {
         rx: event.movementX,
         ry: event.movementY,
+        display_id: displayId,
       };
       if (!this._options.experimental.pointerLock) {
         e.x = event.clientX;
@@ -1657,12 +1836,13 @@ class AnboxStream {
       }
       this._sendInputEvent("mouse-move", e);
     } else if (event.type === "pointerdown" && event.pointerType === "touch") {
-      const index = this._activeTouchPointers.indexOf(event.pointerId);
-      if (index === -1) this._activeTouchPointers.push(event.pointerId);
+      const index = state.activeTouchPointers.indexOf(event.pointerId);
+      if (index === -1) state.activeTouchPointers.push(event.pointerId);
       this._sendInputEvent("touch-start", {
         id: event.pointerId,
         x: event.clientX,
         y: event.clientY,
+        display_id: displayId,
       });
     } else if (event.type === "pointerdown" && event.pointerType === "mouse") {
       const button = this._getPressedButton(event);
@@ -1670,13 +1850,14 @@ class AnboxStream {
       this._sendInputEvent("mouse-button", {
         pressed: true,
         button: button,
+        display_id: displayId,
       });
     } else if (
       (event.type === "pointerup" || event.type === "pointercancel") &&
       event.pointerType === "touch"
     ) {
-      const index = this._activeTouchPointers.indexOf(event.pointerId);
-      if (index > -1) this._activeTouchPointers.splice(index, 1);
+      const index = state.activeTouchPointers.indexOf(event.pointerId);
+      if (index > -1) state.activeTouchPointers.splice(index, 1);
 
       // Fire the `touch-end` event for each touch points to avoid phantom
       // touch pointer but only includes the `BTN_TOUCH=0` message which is
@@ -1687,10 +1868,11 @@ class AnboxStream {
       // Android frameworks, which is incorrect.
       this._sendInputEvent("touch-end", {
         id: event.pointerId,
-        last: this._activeTouchPointers.length === 0,
+        last: state.activeTouchPointers.length === 0,
+        display_id: displayId,
       });
 
-      delete this._pointerIdsMapper[ori_pointerId];
+      delete state.pointerIdsMapper[ori_pointerId];
     } else if (
       (event.type === "pointerup" || event.type === "pointercancel") &&
       event.pointerType === "mouse"
@@ -1700,21 +1882,23 @@ class AnboxStream {
       this._sendInputEvent("mouse-button", {
         pressed: false,
         button: button,
+        display_id: displayId,
       });
     }
   }
 
-  _findPointerId(pointerId) {
+  _findPointerId(pointerId, state) {
     // AOSP supports max 10 touch points and we use the pointerId as the ABS_MT_SLOT
     // and ABS_MT_TRACKING_ID passing down to the container. However the pointerEvent.pointerId
     // would be increased all the time when lifting one finger up and down in a short
     // amount period of time when it comes to multiple touch scenario. Hence we need
     // to find out the minimal available pointerId to avoid the it exceeded the max value.
-    if (Object.keys(this._pointerIdsMapper).length > 0) {
-      if (!(pointerId in this._pointerIdsMapper)) {
+    const mapper = state ? state.pointerIdsMapper : this._pointerIdsMapper;
+    if (Object.keys(mapper).length > 0) {
+      if (!(pointerId in mapper)) {
         let existing_pointerIds = [];
-        Object.keys(this._pointerIdsMapper).forEach((id) => {
-          existing_pointerIds.push(this._pointerIdsMapper[id]);
+        Object.keys(mapper).forEach((id) => {
+          existing_pointerIds.push(mapper[id]);
         });
 
         let new_pointerId = 0;
@@ -1723,16 +1907,16 @@ class AnboxStream {
           if (index === -1) break;
         }
 
-        this._pointerIdsMapper[pointerId] = new_pointerId;
+        mapper[pointerId] = new_pointerId;
       }
     } else {
-      this._pointerIdsMapper[pointerId] = pointerId;
+      mapper[pointerId] = pointerId;
     }
 
-    return this._pointerIdsMapper[pointerId];
+    return mapper[pointerId];
   }
 
-  _onMouseWheel(event) {
+  _onMouseWheel(event, displayId = 0) {
     let move_step = (delta) => {
       if (delta === 0) return 0;
       return delta > 0 ? -1 : 1;
@@ -1743,6 +1927,7 @@ class AnboxStream {
       this._sendInputEvent("mouse-wheel", {
         x: movex,
         y: movey,
+        display_id: displayId,
       });
   }
 
@@ -2376,8 +2561,7 @@ class AnboxWebRTCManager {
     this._video_codec_id = null;
     this._audioOutput_codec_id = null;
     this._audioInput_codec_id = null;
-    // All video streams keyed by display index (parsed from server track name "video_N")
-    this._videoStreams = [];
+    this._videoStreams = {};
 
     this._stream = {
       video: options.enableVideoStream,
@@ -2484,7 +2668,7 @@ class AnboxWebRTCManager {
     this._onReady = (videoStream, audioStream) => {};
     this._onClose = () => {};
     // eslint-disable-next-line no-unused-vars
-    this._onExtraVideoTrack = (trackIndex, stream) => {};
+    this._onExtraVideoTrack = (displayId, stream) => {};
     this._onMicRequested = () => false;
     this._onCameraRequested = () => false;
     // eslint-disable-next-line no-unused-vars

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -436,6 +436,7 @@ class AnboxStream {
         if (video.videoWidth > 0 && video.videoHeight > 0) computeDims();
       });
       ro.observe(container);
+      this._displayStates[displayId].resizeObserver = ro;
     }
 
     if (displayId !== 0) {
@@ -1262,6 +1263,14 @@ class AnboxStream {
     const audio = document.getElementById(this._audioID);
     if (video) video.remove();
     if (audio) audio.remove();
+
+    // Disconnect ResizeObservers to avoid stale callbacks after teardown.
+    for (const state of Object.values(this._displayStates)) {
+      if (state.resizeObserver) {
+        state.resizeObserver.disconnect();
+        state.resizeObserver = null;
+      }
+    }
 
     const initialContainerID = this._options.targetElement || null;
     this._containerIDs = initialContainerID ? { 0: initialContainerID } : {};

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -182,6 +182,7 @@ class AnboxStream {
       preferredVideoDecoderCodecs: this._options.video.preferred_decoder_codecs,
     });
     this._webrtcManager.onReady(this._webrtcReady.bind(this));
+    this._webrtcManager.onExtraVideoTrack(this._onExtraVideoTrack.bind(this));
     this._webrtcManager.onError((err) => {
       this._stopStreamingOnError(err.message, err.cause.code);
     });
@@ -2375,6 +2376,8 @@ class AnboxWebRTCManager {
     this._video_codec_id = null;
     this._audioOutput_codec_id = null;
     this._audioInput_codec_id = null;
+    // All video streams keyed by display index (parsed from server track name "video_N")
+    this._videoStreams = [];
 
     this._stream = {
       video: options.enableVideoStream,
@@ -2480,6 +2483,8 @@ class AnboxWebRTCManager {
     // eslint-disable-next-line no-unused-vars
     this._onReady = (videoStream, audioStream) => {};
     this._onClose = () => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onExtraVideoTrack = (trackIndex, stream) => {};
     this._onMicRequested = () => false;
     this._onCameraRequested = () => false;
     // eslint-disable-next-line no-unused-vars
@@ -2513,6 +2518,22 @@ class AnboxWebRTCManager {
    */
   onReady(callback) {
     this._onReady = callback;
+  }
+
+  /**
+   * @callback onExtraVideoTrack
+   * @param displayId {number} Zero-based display index derived from the server-assigned
+   *   track name ("video_N"). Stable across dynamic display add/remove.
+   * @param stream {MediaStream} Stream to attach to the extra video element
+   */
+  /**
+   * Called when an additional video track is received.
+   * The display index is parsed from the server-assigned track name and is
+   * stable even when displays are added or removed dynamically.
+   * @param callback {onExtraVideoTrack}
+   */
+  onExtraVideoTrack(callback) {
+    this._onExtraVideoTrack = callback;
   }
 
   /**
@@ -3286,8 +3307,36 @@ class AnboxWebRTCManager {
   _onRtcTrack(event) {
     const kind = event.track.kind;
     if (kind === "video") {
-      this._videoStream = event.streams[0];
-      this._videoStream.onremovetrack = this._onClose;
+      // The server assigns each video track the label "video_N" (where N is the
+      // display id) via CreateVideoTrack in peer_connection.cpp. On client
+      // side, Parsing it here from MediaStreamTrack.id gives us the correct display
+      // id even when displays are added or removed dynamically.
+      let displayId;
+      const m = event.track.id.match(/^video_(\d+)$/);
+      if (m) {
+        displayId = parseInt(m[1], 10);
+      } else {
+        console.error(
+          `failed to paser display id: ${event.track.id}`,
+        );
+        return;
+      }
+
+      // Wrap the single track in its own MediaStream. All video tracks share
+      // the same stream_id on the server side so event.streams[0] is the same
+      // MediaStream object for every track. A per-track MediaStream guarantees
+      // each video element renders its own display independently.
+      const singleTrackStream = new MediaStream([event.track]);
+      this._videoStreams[displayId] = singleTrackStream;
+
+      if (displayId === 0) {
+        // Primary display (legacy single display)
+        this._videoStream = singleTrackStream;
+        if (event.streams[0]) event.streams[0].onremovetrack = this._onClose;
+      } else {
+        // External displays and notify AnboxStream to wire a new video element
+        this._onExtraVideoTrack(displayId, singleTrackStream);
+      }
     } else if (kind === "audio") {
       this._audioStream = event.streams[0];
       this._audioStream.onremovetrack = this._onClose;

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1891,9 +1891,27 @@ class AnboxStream {
    * @private
    */
   _adjustPointerCoordsToVideoBoundaries(event, displayId) {
-    const videoId = displayId === 0
-      ? this._videoID
-      : `${this._videoID}-display-${displayId}`;
+    const state = this._displayStates[displayId];
+    if (!state) return false;
+
+    if (displayId === 0 && !this._multiDisplayActive) {
+      const container = document.getElementById(this._containerIDs[0]);
+      if (!container) return false;
+      const dim = state.dimensions;
+      if (!dim) return false;
+      const cRect = container.getBoundingClientRect();
+      event.clientX = Math.round(
+        event.clientX - cRect.left - dim.playerOffsetLeft,
+      );
+      event.clientY = Math.round(
+        event.clientY - cRect.top - dim.playerOffsetTop,
+      );
+      return true;
+    }
+
+    // Multi-display mode: use the video element's actual rendered bounding rect.
+    const videoId =
+      displayId === 0 ? this._videoID : `${this._videoID}-display-${displayId}`;
     const video = document.getElementById(videoId);
     if (!video || !video.videoWidth || !video.videoHeight) return false;
 
@@ -1915,25 +1933,21 @@ class AnboxStream {
     // Keep cached dimensions in sync for
     //  1. _isPointerEventOutOfBounds
     //  2. _translateLocalCoordsToRemoteCoords
-    const state = this._displayStates[displayId];
-    if (state) {
-      if (!state.dimensions) {
-        state.dimensions = {
-          videoWidth: video.videoWidth,
-          videoHeight: video.videoHeight,
-          scalePercentage: scale,
-          playerWidth: renderedWidth,
-          playerHeight: renderedHeight,
-          playerOffsetLeft: contentOffsetX,
-          playerOffsetTop: contentOffsetY,
-        };
-      } else {
-        state.dimensions.scalePercentage = scale;
-        state.dimensions.playerWidth = renderedWidth;
-        state.dimensions.playerHeight = renderedHeight;
-        state.dimensions.playerOffsetLeft = contentOffsetX;
-        state.dimensions.playerOffsetTop = contentOffsetY;
-      }
+    const newValues = {
+      scalePercentage: scale,
+      playerWidth: renderedWidth,
+      playerHeight: renderedHeight,
+      playerOffsetLeft: contentOffsetX,
+      playerOffsetTop: contentOffsetY,
+    };
+    if (!state.dimensions) {
+      state.dimensions = {
+        videoWidth: video.videoWidth,
+        videoHeight: video.videoHeight,
+        ...newValues,
+      };
+    } else {
+      state.dimensions = { ...state.dimensions, ...newValues };
     }
 
     return true;
@@ -1950,7 +1964,11 @@ class AnboxStream {
     const dim = this._displayStates[displayId].dimensions;
 
     if (event.pointerType === "touch") {
-      const pos = this._convertTouchInput(event.clientX, event.clientY);
+      const pos = this._convertTouchInput(
+        event.clientX,
+        event.clientY,
+        displayId,
+      );
       event.clientX = pos.x;
       event.clientY = pos.y;
     }

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3769,12 +3769,16 @@ class AnboxWebRTCManager {
       // The server assigns each video track the label "video_N" (where N is the
       // display id) when adding video transceiver. On client side, parsing it
       // here from MediaStreamTrack.id gives us the correct display id.
+      // NOTE: older images use the legacy track name "video", hence treat
+      // those as primary display for backward compatibility.
       let displayId;
       const m = event.track.id.match(/^video_(\d+)$/);
       if (m) {
         displayId = parseInt(m[1], 10);
+      } else if (event.track.id === "video") {
+        displayId = 0;
       } else {
-        console.error(`failed to paser display id: ${event.track.id}`);
+        console.error(`failed to parse display id: ${event.track.id}`);
         return;
       }
 

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -159,12 +159,10 @@ class AnboxStream {
 
     this._id = Math.random().toString(36).substr(2, 9);
 
-    // _containerID is the primary display container. It's reserved for
-    // in single display.
-    this._containerID = options.targetElement || null;
-    // _containerIDs is an array of video container IDs used to attach input listeners
-    // to multiple video tracks.
-    this._containerIDs = this._containerID ? {0: this._containerID} : {};
+    // _containerIDs maps display id to the DOM container id for that display.
+    this._containerIDs = this._options.targetElement
+      ? { 0: this._options.targetElement }
+      : {};
 
     this._videoID = "anbox-stream-video-" + this._id;
     this._audioID = "anbox-stream-audio-" + this._id;
@@ -174,7 +172,7 @@ class AnboxStream {
     this._pendingVideoTracks = {};
     this._pendingReadyCount = 0;
 
-    this._displayStates = this._containerID
+    this._displayStates = this._options.targetElement
       ? {
           0: {
             dimensions: null,
@@ -198,7 +196,7 @@ class AnboxStream {
       dataChannels: this._options.dataChannels,
       foregroundActivity: this._options.foregroundActivity,
       stats: {
-        overlayID: this._containerID,
+        overlayID: this._options.targetElement || null,
         enable: this._options.enableStats,
       },
       debug: this._options.experimental.debug,
@@ -276,38 +274,6 @@ class AnboxStream {
 
     this._originalOrientation = null;
     this._currentRotationDegrees = 0;
-    // Legacy aliases forward to primary display state for any code that was not
-    // yet updated to use the per-display state bag.
-    Object.defineProperty(this, "_dimensions", {
-      get: () => this._displayStates[0].dimensions,
-      set: (v) => {
-        this._displayStates[0].dimensions = v;
-      },
-    });
-    Object.defineProperty(this, "_primaryTouchId", {
-      get: () => this._displayStates[0].primaryTouchId,
-      set: (v) => {
-        this._displayStates[0].primaryTouchId = v;
-      },
-    });
-    Object.defineProperty(this, "_pointersOutofBounds", {
-      get: () => this._displayStates[0].pointersOutofBounds,
-      set: (v) => {
-        this._displayStates[0].pointersOutofBounds = v;
-      },
-    });
-    Object.defineProperty(this, "_activeTouchPointers", {
-      get: () => this._displayStates[0].activeTouchPointers,
-      set: (v) => {
-        this._displayStates[0].activeTouchPointers = v;
-      },
-    });
-    Object.defineProperty(this, "_pointerIdsMapper", {
-      get: () => this._displayStates[0].pointerIdsMapper,
-      set: (v) => {
-        this._displayStates[0].pointerIdsMapper = v;
-      },
-    });
 
     this._displayEventListeners = [];
 
@@ -465,7 +431,7 @@ class AnboxStream {
     // https://bugs.chromium.org/p/chromium/issues/detail?id=462164
     // To work around it we put the outer container in fullscreen and scale the video
     // to fit it. When exiting fullscreen we undo style changes done to the video element
-    const videoContainer = document.getElementById(this._containerID);
+    const videoContainer = document.getElementById(this._containerIDs[0]);
     if (videoContainer.requestFullscreen) {
       videoContainer.requestFullscreen().catch((err) => {
         console.log(
@@ -933,7 +899,7 @@ class AnboxStream {
     // In fully dynamic mode (no targetElement) the video element is not
     // created here. The WebRTC source is stored in _pendingVideoTracks[0]
     // by _webrtcReady() and injected into the DOM by attachDisplay(0).
-    if (!this._containerID) {
+    if (!this._options.targetElement) {
       if (this._options.stream.audio && this._options.devices.speaker) {
         const audio = document.createElement("audio");
         audio.id = this._audioID;
@@ -951,7 +917,7 @@ class AnboxStream {
       return;
     }
 
-    let mediaContainer = document.getElementById(this._containerID);
+    let mediaContainer = document.getElementById(this._options.targetElement);
     // We set the container as relative so the video element is absolute to it and not something else
     mediaContainer.style.position = "relative";
     // Disable native controls for touch events (zooming, panning)
@@ -1769,8 +1735,8 @@ class AnboxStream {
     )
       return;
 
-    const state = this._displayStates[displayId];
-    if (!state) return;
+    const displayState = this._displayStates[displayId];
+    if (!displayState) return;
 
     // The pointerEvent.pointerId increments every time when a new touch point
     // is pressed(can be used to differentiate the touch point from others,
@@ -1781,11 +1747,11 @@ class AnboxStream {
     // correct MT slot event forwarding to Android container.
     const pointerId = Math.abs(pointerEvent.pointerId);
     if (pointerEvent.isPrimary) {
-      state.primaryTouchId = pointerId;
+      displayState.primaryTouchId = pointerId;
     }
 
-    const ori_pointerId = pointerId - state.primaryTouchId;
-    const new_pointerId = this._findPointerId(ori_pointerId, state);
+    const ori_pointerId = pointerId - displayState.primaryTouchId;
+    const new_pointerId = this._findPointerId(ori_pointerId, displayState);
 
     // JS events are read-only, so we create a clone of the event that
     // we can modify down the road
@@ -1814,7 +1780,7 @@ class AnboxStream {
       if (!this._options.experimental.emulatePointerEvent) return;
 
       if (
-        event.pointerId in state.pointersOutofBounds &&
+        event.pointerId in displayState.pointersOutofBounds &&
         event.type != "pointerup"
       )
         return;
@@ -1823,7 +1789,7 @@ class AnboxStream {
       // is out of bounds.
       event.type = "pointerup";
 
-      const dim = state.dimensions;
+      const dim = displayState.dimensions;
       if (event.clientX < 0) {
         event.clientX = 0;
       } else if (event.clientX > dim.playerWidth) {
@@ -1835,10 +1801,10 @@ class AnboxStream {
         event.clientY = dim.playerHeight;
       }
 
-      state.pointersOutofBounds[event.pointerId] = true;
+      displayState.pointersOutofBounds[event.pointerId] = true;
     } else if (
       this._options.experimental.emulatePointerEvent &&
-      event.pointerId in state.pointersOutofBounds
+      event.pointerId in displayState.pointersOutofBounds
     ) {
       // Replace the type of the event with 'pointerdown' if it comes
       // to 'pointermove' event after the event with the type 'pointerup'
@@ -1851,14 +1817,14 @@ class AnboxStream {
         event.type = "pointerdown";
       }
 
-      delete state.pointersOutofBounds[event.pointerId];
+      delete displayState.pointersOutofBounds[event.pointerId];
     }
 
     // Apply video scaling and rotation to the coordinates
     this._translateLocalCoordsToRemoteCoords(event, displayId);
 
     if (event.type === "pointermove" && event.pointerType === "touch") {
-      const index = state.activeTouchPointers.indexOf(event.pointerId);
+      const index = displayState.activeTouchPointers.indexOf(event.pointerId);
       if (index === -1) return;
       this._sendInputEvent("touch-move", {
         id: event.pointerId,
@@ -1878,8 +1844,8 @@ class AnboxStream {
       }
       this._sendInputEvent("mouse-move", e);
     } else if (event.type === "pointerdown" && event.pointerType === "touch") {
-      const index = state.activeTouchPointers.indexOf(event.pointerId);
-      if (index === -1) state.activeTouchPointers.push(event.pointerId);
+      const index = displayState.activeTouchPointers.indexOf(event.pointerId);
+      if (index === -1) displayState.activeTouchPointers.push(event.pointerId);
       this._sendInputEvent("touch-start", {
         id: event.pointerId,
         x: event.clientX,
@@ -1898,8 +1864,8 @@ class AnboxStream {
       (event.type === "pointerup" || event.type === "pointercancel") &&
       event.pointerType === "touch"
     ) {
-      const index = state.activeTouchPointers.indexOf(event.pointerId);
-      if (index > -1) state.activeTouchPointers.splice(index, 1);
+      const index = displayState.activeTouchPointers.indexOf(event.pointerId);
+      if (index > -1) displayState.activeTouchPointers.splice(index, 1);
 
       // Fire the `touch-end` event for each touch points to avoid phantom
       // touch pointer but only includes the `BTN_TOUCH=0` message which is
@@ -1910,11 +1876,11 @@ class AnboxStream {
       // Android frameworks, which is incorrect.
       this._sendInputEvent("touch-end", {
         id: event.pointerId,
-        last: state.activeTouchPointers.length === 0,
+        last: displayState.activeTouchPointers.length === 0,
         display_id: displayId,
       });
 
-      delete state.pointerIdsMapper[ori_pointerId];
+      delete displayState.pointerIdsMapper[ori_pointerId];
     } else if (
       (event.type === "pointerup" || event.type === "pointercancel") &&
       event.pointerType === "mouse"
@@ -1929,13 +1895,15 @@ class AnboxStream {
     }
   }
 
-  _findPointerId(pointerId, state) {
+  _findPointerId(pointerId, displayState) {
     // AOSP supports max 10 touch points and we use the pointerId as the ABS_MT_SLOT
     // and ABS_MT_TRACKING_ID passing down to the container. However the pointerEvent.pointerId
     // would be increased all the time when lifting one finger up and down in a short
     // amount period of time when it comes to multiple touch scenario. Hence we need
     // to find out the minimal available pointerId to avoid the it exceeded the max value.
-    const mapper = state ? state.pointerIdsMapper : this._pointerIdsMapper;
+    const mapper = displayState
+      ? displayState.pointerIdsMapper
+      : this._displayStates[0].pointerIdsMapper;
     if (Object.keys(mapper).length > 0) {
       if (!(pointerId in mapper)) {
         let existing_pointerIds = [];
@@ -2063,8 +2031,10 @@ class AnboxStream {
    * @return coordinates.y {Number} updated Y coordinate
    * @private
    */
-  _convertTouchInput(x, y) {
-    const dim = this._dimensions;
+  _convertTouchInput(x, y, displayId = 0) {
+    const dim = this._displayStates[displayId]
+      ? this._displayStates[displayId].dimensions
+      : this._displayStates[0].dimensions;
     if (!dim) {
       throw newError("sdk is not ready yet", ANBOX_STREAM_SDK_ERROR_INTERNAL);
     }
@@ -2113,7 +2083,7 @@ class AnboxStream {
   }
 
   _setVideoContainerFocused(enabled) {
-    const videoContainer = document.getElementById(this._containerID);
+    const videoContainer = document.getElementById(this._containerIDs[0]);
     videoContainer.contentEditable = enabled;
     if (videoContainer.contentEditable) videoContainer.focus();
     else videoContainer.blur();

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -790,6 +790,12 @@ class AnboxStream {
     if (this._nullOrUndef(options.callbacks.vhalReady))
       options.callbacks.vhalReady = () => {};
 
+    if (this._nullOrUndef(options.callbacks.videoTrackAdded))
+      options.callbacks.videoTrackAdded = () => {};
+
+    if (this._nullOrUndef(options.callbacks.videoTrackRemoved))
+      options.callbacks.videoTrackRemoved = () => {};
+
     if (!this._nullOrUndef(options.dataChannels)) {
       if (Object.keys(options.dataChannels).length > maxNumberOfDataChannels) {
         throw newError(
@@ -914,7 +920,37 @@ class AnboxStream {
     }
   }
 
+  // Fire ready() only when display 0 has played AND all secondary display
+  // tracks that arrived before display 0 played have also started playing.
+  // _pendingReadyCount tracks how many secondary tracks are still pending.
+  _checkReady() {
+    if (this._primaryDisplayReady && this._pendingReadyCount === 0) {
+      this._options.callbacks.ready();
+    }
+  }
+
   _createMedia() {
+    // In fully dynamic mode (no targetElement) the video element is not
+    // created here. The WebRTC source is stored in _pendingVideoTracks[0]
+    // by _webrtcReady() and injected into the DOM by attachDisplay(0).
+    if (!this._containerID) {
+      if (this._options.stream.audio && this._options.devices.speaker) {
+        const audio = document.createElement("audio");
+        audio.id = this._audioID;
+        audio.autoplay = true;
+        audio.controls = false;
+        if (!this._options.stream.video) {
+          audio.onplay = () => {
+            this._primaryDisplayReady = true;
+            this._checkReady();
+            this._options.callbacks.videoTrackAdded(0);
+          };
+        }
+        document.body.appendChild(audio);
+      }
+      return;
+    }
+
     let mediaContainer = document.getElementById(this._containerID);
     // We set the container as relative so the video element is absolute to it and not something else
     mediaContainer.style.position = "relative";
@@ -928,7 +964,7 @@ class AnboxStream {
       video.style.margin = "0";
       video.style.height = "auto";
       video.style.width = "auto";
-      // The video element is sized based on the dimensions of its container. Settings its position to "absolute"
+      // The video element is sized based on the dimensions of its container. Setting its position to "absolute"
       // removes it from the flow, so the video element cannot change its parent dimensions.
       video.style.position = "absolute";
       video.muted = true;
@@ -941,7 +977,9 @@ class AnboxStream {
       video.onplay = () => {
         this._onResize();
         this._registerControls();
-        this._options.callbacks.ready();
+        this._primaryDisplayReady = true;
+        this._checkReady();
+        this._options.callbacks.videoTrackAdded(0);
       };
       video.onloadedmetadata = () => {
         // NOTE: the video frame may not be received or fully decoded yet
@@ -993,7 +1031,9 @@ class AnboxStream {
       audio.controls = false;
       if (!this._options.stream.video) {
         audio.onplay = () => {
-          this._options.callbacks.ready();
+          this._primaryDisplayReady = true;
+          this._checkReady();
+          this._options.callbacks.videoTrackAdded(0);
         };
       }
       mediaContainer.appendChild(audio);
@@ -1023,7 +1063,9 @@ class AnboxStream {
     }
 
     if (!this._options.stream.video && !this._options.stream.audio) {
-      this._options.callbacks.ready();
+      this._primaryDisplayReady = true;
+      this._checkReady();
+      this._options.callbacks.videoTrackAdded(0);
     }
   }
 

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -86,7 +86,12 @@ class AnboxStream {
    * displays its video & audio feed in an HTML5 player
    * @param options: {object}
    * @param options.connector {object} WebRTC Stream connector.
-   * @param options.targetElement {string} ID of the DOM element to attach the video to.
+   * @param [options.targetElement] {string} ID of the DOM element to attach the primary (display 0)
+   *   video to. When provided the SDK operates in legacy single-display mode: the primary video is
+   *   injected automatically, and the `videoTrackAdded` callback fires for every display that arrives
+   *   (including display 0). When omitted the SDK operates in fully dynamic mode: the caller MUST
+   *   call `attachDisplay(displayId, containerId)` for every display, including display 0, in
+   *   response to the `videoTrackAdded` callback.
    * @param [options.verticalAlignment=center] {top | center | bottom} Vertical alignment of the video element in its container.
    * @param [options.fullScreen=false] {boolean} Stream video in full screen mode.
    * @param [options.deviceType] {string} Send the type of device the SDK is running on to the Android container.
@@ -124,6 +129,13 @@ class AnboxStream {
    * @param [options.callbacks.requestCameraAccess=none] {function} Called when Android application tries to open camera device for video streaming.
    * @param [options.callbacks.requestMicrophoneAccess=none] {function} Called when Android application tries to open microphone device for video streaming.
    * @param [options.callbacks.vhalReady=none] {function} Called when the VHAL manager has been initialised.
+   * @param [options.callbacks.videoTrackAdded=none] {function} Called when a display video track is
+   *   added. Receives (displayId). Fires for every display, starting from display 0.
+   *   In dynamic mode (no `targetElement`): call `sdk.attachDisplay(displayId, containerId)`
+   *   after the container is in the DOM to have the SDK inject the video element.
+   *   In legacy mode (`targetElement` provided): display 0 is already injected; call
+   *   `sdk.attachDisplay(displayId, containerId)` for displays 1 and above.
+   * @param [options.callbacks.videoTrackRemoved=none] {function} Called when a display video track is removed. Receives (displayId).
    * @param [options.dataChannels] {object} Map of data channels used to exchange out of band data between WebRTC client and application running in Android container.
    * @param [options.dataChannels[name].callbacks] {object} A list of event handling callbacks of one specific data channel.
    * @param [options.dataChannels[name].callbacks.open=none] {function} A callback function that is triggered when the data channel is opened.
@@ -333,6 +345,106 @@ class AnboxStream {
   disconnect() {
     this._stopStreaming();
     this._options.connector.disconnect();
+  }
+
+  /**
+   * Attach a consumer-provided container to a display.
+   *
+   * In legacy mode (`targetElement` provided): display 0 is managed by the SDK,
+   * so this should only be called for displays with index >= 1, in response to
+   * the `videoTrackAdded` callback.
+   *
+   * In fully dynamic mode (no `targetElement`): must be called for every display
+   * including display 0, in response to the `videoTrackAdded` callback. The SDK
+   * will inject a `<video>` element into the container, set up input routing,
+   * and begin computing dimensions for that display.
+   *
+   * @param {number} displayId - The display id reported by `videoTrackAdded`.
+   * @param {string} containerId  - The DOM `id` of the container element to
+   *                                inject the video into. The element must
+   *                                already be present in the DOM.
+   */
+  attachDisplay(displayId, containerId) {
+    if (displayId === 0 && this._options.targetElement) {
+      // Legacy mode: display 0 is already managed by targetElement. Nothing to do.
+      return;
+    }
+
+    const stream = this._pendingVideoTracks[displayId];
+    if (!stream) {
+      console.warn(
+        `[AnboxStream] attachDisplay(${displayId}) called but no pending stream. ` +
+          "Call this method from within the videoTrackAdded callback.",
+      );
+      return;
+    }
+
+    const container = document.getElementById(containerId);
+    if (!container) {
+      console.error(
+        `[AnboxStream] attachDisplay(${displayId}): container #${containerId} not found in DOM.`,
+      );
+      return;
+    }
+
+    delete this._pendingVideoTracks[displayId];
+
+    container.style.position = "relative";
+    container.style.overflow = "hidden";
+    container.style.touchAction = "none";
+
+    this._containerIDs[displayId] = containerId;
+
+    if (!(displayId in this._displayStates)) {
+      this._displayStates[displayId] = {
+        dimensions: null,
+        activeTouchPointers: [],
+        pointerIdsMapper: {},
+        primaryTouchId: 0,
+        pointersOutofBounds: {},
+      };
+    }
+
+    this._multiDisplayActive = true;
+
+    const videoId =
+      displayId === 0 ? this._videoID : `${this._videoID}-display-${displayId}`;
+    const video = this._createExtraVideoElement(videoId, stream);
+    container.appendChild(video);
+
+    const computeDims = () =>
+      this._computeMultiDisplayDimensions(video, container, displayId);
+    video.addEventListener("loadedmetadata", computeDims);
+    video.addEventListener("resize", computeDims);
+    video.addEventListener(
+      "play",
+      () => {
+        if (displayId === 0) {
+          this._registerControls();
+          this._primaryDisplayReady = true;
+        } else {
+          this._pendingReadyCount = Math.max(0, this._pendingReadyCount - 1);
+        }
+        this._checkReady();
+      },
+      { once: true },
+    );
+
+    // Recompute when the container cell resizes.
+    if (typeof ResizeObserver !== "undefined") {
+      const ro = new ResizeObserver(() => {
+        if (video.videoWidth > 0 && video.videoHeight > 0) computeDims();
+      });
+      ro.observe(container);
+    }
+
+    if (displayId !== 0) {
+      this._registerInputHandlers(displayId, container);
+
+      // Recompute all display dimensions now that the layout has changed.
+      // Use a short timeout so the browser has flushed the new layout.
+      setTimeout(() => this._onResize(), 0);
+    }
   }
 
   /**
@@ -834,23 +946,24 @@ class AnboxStream {
   _validateOptions(options) {
     this._validateApiVersion(options.apiVersion);
 
-    if (this._nullOrUndef(options.targetElement)) {
-      throw newError(
-        "missing targetElement parameter",
-        ANBOX_STREAM_SDK_ERROR_INVALID_ARGUMENT,
-      );
+    if (!this._nullOrUndef(options.targetElement)) {
+      if (typeof options.targetElement !== "string") {
+        throw newError(
+          "targetElement must be a string ID",
+          ANBOX_STREAM_SDK_ERROR_INVALID_ARGUMENT,
+        );
+      }
+      const container = document.getElementById(options.targetElement);
+      if (container === null) {
+        throw newError(
+          `target element "${options.targetElement}" does not exist`,
+          ANBOX_STREAM_SDK_ERROR_INVALID_ARGUMENT,
+        );
+      } else if (container.clientWidth === 0 || container.clientHeight === 0)
+        console.error(
+          `[AnboxStream] video container element "${options.targetElement}" misses size. Please see https://canonical.com/anbox-cloud/docs/tutorial/stream-client`,
+        );
     }
-
-    const container = document.getElementById(options.targetElement);
-    if (container === null) {
-      throw newError(
-        `target element "${options.targetElement}" does not exist`,
-        ANBOX_STREAM_SDK_ERROR_INVALID_ARGUMENT,
-      );
-    } else if (container.clientWidth == 0 || container.clientHeight == 0)
-      console.error(
-        "AnboxStream: video container element misses size. Please see https://canonical.com/anbox-cloud/docs/tutorial/stream-client",
-      );
 
     if (this._nullOrUndef(options.connector)) {
       throw newError(
@@ -1014,13 +1127,23 @@ class AnboxStream {
 
   _webrtcReady(videoSource, audioSource) {
     if (this._options.stream.video) {
-      const video = document.getElementById(this._videoID);
-      video.srcObject = videoSource;
+      if (!this._options.targetElement) {
+        // Guard against _webrtcReady being called again on subsequent track
+        // arrivals (the WebRTC manager re-fires the ready callback for every
+        // track once the primary conditions are satisfied).
+        if (!(0 in this._pendingVideoTracks)) {
+          this._pendingVideoTracks[0] = videoSource;
+          this._options.callbacks.videoTrackAdded(0);
+        }
+      } else {
+        const video = document.getElementById(this._videoID);
+        video.srcObject = videoSource;
 
-      // Expliclity to call play() method to the video element if it's hidden,
-      // otherwise video can be still buffered but not playback, which caused
-      // the video.onplay callback won't be triggered at all.
-      if (video.style.display === "none") video.play();
+        // Expliclity to call play() method to the video element if it's hidden,
+        // otherwise video can be still buffered but not playback, which caused
+        // the video.onplay callback won't be triggered at all.
+        if (video.style.display === "none") video.play();
+      }
     }
 
     if (this._options.stream.audio && this._options.devices.speaker) {
@@ -1035,12 +1158,124 @@ class AnboxStream {
     }
   }
 
+  _onExtraVideoTrack(displayId, stream) {
+    const videoId = `${this._videoID}-display-${displayId}`;
+    if (document.getElementById(videoId)) {
+      document.getElementById(videoId).srcObject = stream;
+      return;
+    }
+
+    this._pendingReadyCount++;
+    this._pendingVideoTracks[displayId] = stream;
+    this._options.callbacks.videoTrackAdded(displayId);
+  }
+
+  _activateMultiDisplayGrid(container) {
+    this._multiDisplayActive = true;
+
+    // Wrap the primary video in a dedicated cell div so it becomes one
+    // equal grid item alongside the additional display cells.
+    const cell = document.createElement("div");
+    cell.id = `${this._videoID}-cell-0`;
+    cell.className = "anbox-stream-cell";
+    cell.style.position = "relative";
+    cell.style.overflow = "hidden";
+
+    const primaryVideo = document.getElementById(this._videoID);
+    if (primaryVideo) {
+      // Make the primary video fill its new cell via absolute positioning,
+      // consistent with how secondary videos are rendered.
+      primaryVideo.style.position = "absolute";
+      primaryVideo.style.inset = "0";
+      primaryVideo.style.width = "100%";
+      primaryVideo.style.height = "100%";
+      primaryVideo.style.objectFit = "contain";
+      primaryVideo.style.top = "";
+      primaryVideo.style.left = "";
+      primaryVideo.style.maxWidth = "";
+      primaryVideo.style.maxHeight = "";
+      cell.appendChild(primaryVideo);
+    }
+    container.insertBefore(cell, container.firstChild);
+
+    // Move the display 0 input zone from the outer container to cell-0 so
+    // pointer events are scoped to the actual video area.
+    this._unregisterInputHandlers(0);
+    this._containerIDs[0] = cell.id;
+    this._registerInputHandlers(0, cell);
+
+    container.style.display = "grid";
+    container.style.width = "100%";
+    container.style.height = "100%";
+    container.style.gap = "0";
+    container.style.overflow = "hidden";
+    container.style.boxSizing = "border-box";
+  }
+
+  _createExtraVideoElement(id, stream) {
+    const video = document.createElement("video");
+    video.id = id;
+    video.style.margin = "0";
+    video.style.position = "absolute";
+    video.muted = true;
+    video.autoplay = true;
+    video.controls = false;
+    video.playsInline = true;
+    video.setAttribute("oncontextmenu", "return false;");
+    video.srcObject = stream;
+    return video;
+  }
+
+  _updateGridColumns(container) {
+    const count = container.querySelectorAll(".anbox-stream-cell").length;
+    const cols = Math.ceil(Math.sqrt(count));
+    const rows = Math.ceil(count / cols);
+    container.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+    container.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+  }
+
   _removeMedia() {
+    this._multiDisplayActive = false;
+    this._primaryDisplayReady = false;
+    this._pendingReadyCount = 0;
+
+    // Notify consumer for each attached display (highest id first), then
+    // clean up any pending streams that were never attached.
+    const attachedIds = Object.keys(this._containerIDs)
+      .map(Number)
+      .sort((a, b) => b - a);
+    for (const displayId of attachedIds) {
+      this._options.callbacks.videoTrackRemoved(displayId);
+    }
+    this._pendingVideoTracks = {};
+
+    // First remove additional video elements injected by attachDisplay,
+    // then Remove primary video and audio elements.
+    for (const displayId of attachedIds) {
+      if (displayId === 0) continue;
+      const el = document.getElementById(
+        `${this._videoID}-display-${displayId}`,
+      );
+      if (el) el.remove();
+    }
     const video = document.getElementById(this._videoID);
     const audio = document.getElementById(this._audioID);
-
     if (video) video.remove();
     if (audio) audio.remove();
+
+    const initialContainerID = this._options.targetElement || null;
+    this._containerIDs = initialContainerID ? { 0: initialContainerID } : {};
+    this._displayStates = initialContainerID
+      ? {
+          0: {
+            dimensions: null,
+            activeTouchPointers: [],
+            pointerIdsMapper: {},
+            primaryTouchId: 0,
+            pointersOutofBounds: {},
+          },
+        }
+      : {};
   }
 
   _stopStreaming() {
@@ -1368,15 +1603,20 @@ class AnboxStream {
 
   _onResize() {
     const video = document.getElementById(this._videoID);
-    const container = document.getElementById(this._containerID);
+    const container = document.getElementById(
+      this._options.targetElement || this._containerIDs[0],
+    );
     if (video === null || container === null) return;
     if (video.videoWidth === 0 || video.videoHeight === 0) return;
 
     // In multi-display mode, recompute all attached displays so that any
     // layout changes (new display added, window resize) are reflected.
     if (this._multiDisplayActive) {
-      this._computeMultiDisplayDimensions(video, container, 0);
-      const extraIds = Object.keys(this._containerIDs).map(Number).filter(i => i > 0);
+      const cell = document.getElementById(this._containerIDs[0]) || container;
+      this._computeMultiDisplayDimensions(video, cell, 0);
+      const extraIds = Object.keys(this._containerIDs)
+        .map(Number)
+        .filter((i) => i > 0);
       for (const i of extraIds) {
         const secId = `${this._videoID}-display-${i}`;
         const secVideo = document.getElementById(secId);
@@ -1637,11 +1877,15 @@ class AnboxStream {
    * removes the various offsets so the (0,0) coordinate corresponds to
    * the top left corner of the video content for the given display.
    *
-   * Uses _containerIDs[displayId] as the reference element so that in
-   * dynamic single-container mode, coordinates are computed against the
-   * correct cell div (not the outer container), even after the grid layout
-   * changes. Scale and offsets are recomputed live to avoid stale values
-   * when containers resize (e.g. secondary displays appearing).
+   * For primary display in single-display mode, uses the cached dimensions
+   * computed by _onResize (which correctly handles CSS rotation) together
+   * with the container's bounding rect.
+   *
+   * In multi-display mode, display 0's video element is explicitly sized and
+   * positioned in pixels by _computeMultiDisplayDimensions (just like extra
+   * displays), so we use the video element's getBoundingClientRect directly.
+   * This avoids any dependency on the outer grid container's dimensions.
+   *
    * @param event
    * @param {number} displayId
    * @private
@@ -2573,6 +2817,7 @@ class AnboxWebRTCManager {
     this._video_codec_id = null;
     this._audioOutput_codec_id = null;
     this._audioInput_codec_id = null;
+    // All video streams keyed by display id
     this._videoStreams = {};
 
     this._stream = {
@@ -2718,13 +2963,13 @@ class AnboxWebRTCManager {
 
   /**
    * @callback onExtraVideoTrack
-   * @param displayId {number} Zero-based display index derived from the server-assigned
-   *   track name ("video_N"). Stable across dynamic display add/remove.
+   * @param displayId {number} zero-based display id derived from the server-assigned
+   *   track name.
    * @param stream {MediaStream} Stream to attach to the extra video element
    */
   /**
    * Called when an additional video track is received.
-   * The display index is parsed from the server-assigned track name and is
+   * The display id is parsed from the server-assigned track name and is
    * stable even when displays are added or removed dynamically.
    * @param callback {onExtraVideoTrack}
    */
@@ -3504,17 +3749,14 @@ class AnboxWebRTCManager {
     const kind = event.track.kind;
     if (kind === "video") {
       // The server assigns each video track the label "video_N" (where N is the
-      // display id) via CreateVideoTrack in peer_connection.cpp. On client
-      // side, Parsing it here from MediaStreamTrack.id gives us the correct display
-      // id even when displays are added or removed dynamically.
+      // display id) when adding video transceiver. On client side, parsing it
+      // here from MediaStreamTrack.id gives us the correct display id.
       let displayId;
       const m = event.track.id.match(/^video_(\d+)$/);
       if (m) {
         displayId = parseInt(m[1], 10);
       } else {
-        console.error(
-          `failed to paser display id: ${event.track.id}`,
-        );
+        console.error(`failed to paser display id: ${event.track.id}`);
         return;
       }
 
@@ -3526,12 +3768,16 @@ class AnboxWebRTCManager {
       this._videoStreams[displayId] = singleTrackStream;
 
       if (displayId === 0) {
-        // Primary display (legacy single display)
         this._videoStream = singleTrackStream;
-        if (event.streams[0]) event.streams[0].onremovetrack = this._onClose;
+        // Close the session when the primary display track ends while
+        // for any other displays, just notify the consumer to detach only
+        // this display when its track ends.
+        event.track.onended = this._onClose;
       } else {
-        // External displays and notify AnboxStream to wire a new video element
+        // Notify AnboxStream to attach the new video track to a video container.
         this._onExtraVideoTrack(displayId, singleTrackStream);
+        event.track.onended = () =>
+          this._options.callbacks.videoTrackRemoved(displayId);
       }
     } else if (kind === "audio") {
       this._audioStream = event.streams[0];
@@ -3540,7 +3786,7 @@ class AnboxWebRTCManager {
 
     const audioOnly = !this._stream.video && this._stream.audio;
     const videoOnly = this._stream.video && !this._stream.audio;
-    // Prevent streaming until regardind tracks are available
+    // Do not fire ready callback until regarding tracks are available.
     if (
       (audioOnly && this._audioStream) ||
       (videoOnly && this._videoStream) ||

--- a/js/tests/e2e/package-lock.json
+++ b/js/tests/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.22.0",
       "license": "Proprietary",
       "dependencies": {
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "compressing": "1.10.5",
         "dotenv": "16.4.7",
         "express": "4.22.2",
@@ -774,6 +774,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -881,13 +893,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1342,7 +1355,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2397,6 +2409,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -5069,6 +5094,14 @@
       "dev": true,
       "requires": {}
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -5146,12 +5179,13 @@
       }
     },
     "axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "requires": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5473,7 +5507,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.3"
       }
@@ -6177,6 +6210,15 @@
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "iconv-lite": {

--- a/js/tests/e2e/package.json
+++ b/js/tests/e2e/package.json
@@ -24,7 +24,7 @@
     "v8-to-istanbul": "9.3.0"
   },
   "dependencies": {
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "compressing": "1.10.5",
     "dotenv": "16.4.7",
     "express": "4.22.2",

--- a/js/tests/unit/input-events.test.js
+++ b/js/tests/unit/input-events.test.js
@@ -80,7 +80,10 @@ test("rotated touch events are properly translated", () => {
     stop: jest.fn(),
   };
 
-  stream._dimensions = { playerWidth: 500, playerHeight: 1000 };
+  stream._displayStates[0].dimensions = {
+    playerWidth: 500,
+    playerHeight: 1000,
+  };
   expect(stream.rotate(0)).toEqual(true);
   let coord = stream._convertTouchInput(0, 0);
   expect(coord).toEqual({ x: 0, y: 0 });
@@ -94,7 +97,10 @@ test("rotated touch events are properly translated", () => {
     },
   );
 
-  stream._dimensions = { playerWidth: 1000, playerHeight: 500 };
+  stream._displayStates[0].dimensions = {
+    playerWidth: 1000,
+    playerHeight: 500,
+  };
   expect(stream.rotate(90)).toEqual(true);
   coord = stream._convertTouchInput(1000, 0);
   expect(stream._webrtcManager.sendControlMessage).toHaveBeenLastCalledWith(
@@ -107,7 +113,10 @@ test("rotated touch events are properly translated", () => {
     },
   );
 
-  stream._dimensions = { playerWidth: 500, playerHeight: 1000 };
+  stream._displayStates[0].dimensions = {
+    playerWidth: 500,
+    playerHeight: 1000,
+  };
   expect(stream.rotate(180)).toEqual(true);
   coord = stream._convertTouchInput(500, 1000);
   expect(coord).toEqual({ x: 500, y: 1000 });
@@ -121,7 +130,10 @@ test("rotated touch events are properly translated", () => {
     },
   );
 
-  stream._dimensions = { playerWidth: 1000, playerHeight: 500 };
+  stream._displayStates[0].dimensions = {
+    playerWidth: 1000,
+    playerHeight: 500,
+  };
   expect(stream.rotate(270)).toEqual(true);
   coord = stream._convertTouchInput(0, 500);
   expect(coord).toEqual({ x: 500, y: 0 });
@@ -210,7 +222,7 @@ test("can process mouse button events", () => {
   });
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Check disabled key combinations
   container.dispatchEvent(
@@ -233,7 +245,11 @@ test("can process mouse button events", () => {
   ); // scroll wheel button
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::mouse-button");
-  expect(mockFn.mock.calls[0][1]).toEqual({ button: 5, pressed: true });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    button: 5,
+    pressed: true,
+    display_id: 0,
+  });
 
   container.dispatchEvent(
     new PointerEvent("pointerup", {
@@ -245,7 +261,11 @@ test("can process mouse button events", () => {
   );
   expect(mockFn.mock.calls.length).toEqual(2);
   expect(mockFn.mock.calls[1][0]).toEqual("input::mouse-button");
-  expect(mockFn.mock.calls[1][1]).toEqual({ button: 5, pressed: false });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    button: 5,
+    pressed: false,
+    display_id: 0,
+  });
 });
 
 test("can process mouse move events", () => {
@@ -257,7 +277,7 @@ test("can process mouse move events", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   const event = new PointerEvent("pointermove", {
     clientX: 1000,
@@ -270,7 +290,13 @@ test("can process mouse move events", () => {
 
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 250, y: 500, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 250,
+    y: 500,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 });
 
 test("can process mouse move events with pointer lock", () => {
@@ -286,7 +312,7 @@ test("can process mouse move events with pointer lock", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   document.pointerLockElement = {};
 
@@ -303,7 +329,7 @@ test("can process mouse move events with pointer lock", () => {
   expect(mockFn.mock.calls[0][0]).toEqual("input::mouse-move");
   // With pointer lock enabled we should only see movement information
   // and absolute position
-  expect(mockFn.mock.calls[0][1]).toEqual({ rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[0][1]).toEqual({ rx: 25, ry: 50, display_id: 0 });
 });
 
 test("can process mouse events translated to touch events", () => {
@@ -316,7 +342,7 @@ test("can process mouse events translated to touch events", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   let event = new PointerEvent("pointerdown", {
     clientX: 1000,
@@ -351,11 +377,21 @@ test("can process mouse events translated to touch events", () => {
   expect(mockFn.mock.calls.length).toEqual(3);
   expect(mockFn.mock.calls.length).toEqual(3);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 250, y: 500, id: 1 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 250,
+    y: 500,
+    id: 1,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[1][1]).toEqual({ x: 251, y: 501, id: 1 });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    x: 251,
+    y: 501,
+    id: 1,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 1, last: true });
+  expect(mockFn.mock.calls[2][1]).toEqual({ id: 1, last: true, display_id: 0 });
 });
 
 test("ignore pointermove events after the pointerup event is fired on touch emulation", () => {
@@ -368,7 +404,7 @@ test("ignore pointermove events after the pointerup event is fired on touch emul
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   let event = new PointerEvent("pointerdown", {
     clientX: 1000,
@@ -404,9 +440,14 @@ test("ignore pointermove events after the pointerup event is fired on touch emul
   expect(mockFn.mock.calls.length).toEqual(2);
   expect(mockFn.mock.calls.length).toEqual(2);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 250, y: 500, id: 1 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 250,
+    y: 500,
+    id: 1,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[1][1]).toEqual({ id: 1, last: true });
+  expect(mockFn.mock.calls[1][1]).toEqual({ id: 1, last: true, display_id: 0 });
 });
 
 test("can process touch events", () => {
@@ -418,7 +459,7 @@ test("can process touch events", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Simulate 3 touches, 0 end, 1 doesn't change, 2 moves
   let touches = [
@@ -433,14 +474,24 @@ test("can process touch events", () => {
 
   expect(mockFn.mock.calls.length).toEqual(3);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 0, y: 0 });
+  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 0, y: 0, display_id: 0 });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[1][1]).toEqual({ id: 1, x: 250, y: 500 });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    id: 1,
+    x: 250,
+    y: 500,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 2, x: 500, y: 1000 });
+  expect(mockFn.mock.calls[2][1]).toEqual({
+    id: 2,
+    x: 500,
+    y: 1000,
+    display_id: 0,
+  });
 
-  touches[2].clientX = stream._dimensions.playerOffsetLeft;
-  touches[2].clientY = stream._dimensions.playerOffsetTop;
+  touches[2].clientX = stream._displayStates[0].dimensions.playerOffsetLeft;
+  touches[2].clientY = stream._displayStates[0].dimensions.playerOffsetTop;
   container.dispatchEvent(new PointerEvent("pointermove", touches[2]));
 
   // Fire the `pointerup` for the first touch point will trigger `touch-end`
@@ -449,9 +500,13 @@ test("can process touch events", () => {
 
   expect(mockFn.mock.calls.length).toEqual(5);
   expect(mockFn.mock.calls[3][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[3][1]).toEqual({ id: 2, x: 0, y: 0 });
+  expect(mockFn.mock.calls[3][1]).toEqual({ id: 2, x: 0, y: 0, display_id: 0 });
   expect(mockFn.mock.calls[4][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[4][1]).toEqual({ id: 2, last: false });
+  expect(mockFn.mock.calls[4][1]).toEqual({
+    id: 2,
+    last: false,
+    display_id: 0,
+  });
 
   // Fire the `pointerup` for the remaining touch points the end
   // of multi-touch transfer. And the last point event that
@@ -461,9 +516,13 @@ test("can process touch events", () => {
 
   expect(mockFn.mock.calls.length).toEqual(7);
   expect(mockFn.mock.calls[5][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[5][1]).toEqual({ id: 1, last: false });
+  expect(mockFn.mock.calls[5][1]).toEqual({
+    id: 1,
+    last: false,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[6][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[6][1]).toEqual({ id: 0, last: true });
+  expect(mockFn.mock.calls[6][1]).toEqual({ id: 0, last: true, display_id: 0 });
 });
 
 test("can process invalid touch events", () => {
@@ -473,14 +532,14 @@ test("can process invalid touch events", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   let touch = { pointerType: "touch", pointerId: -1, clientX: 500, clientY: 0 };
   container.dispatchEvent(new PointerEvent("pointerdown", touch));
 
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 1, x: 0, y: 0 });
+  expect(mockFn.mock.calls[0][1]).toEqual({ id: 1, x: 0, y: 0, display_id: 0 });
 });
 
 test("mouse move when rotated", () => {
@@ -497,7 +556,7 @@ test("mouse move when rotated", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Mouse move event at bottom right corner
   let event = new PointerEvent("pointermove", {
@@ -510,7 +569,13 @@ test("mouse move when rotated", () => {
   container.dispatchEvent(event);
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 500, y: 1000, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 500,
+    y: 1000,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 
   expect(stream.rotate(-90)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -522,7 +587,13 @@ test("mouse move when rotated", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[2][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[2][1]).toEqual({ x: 0, y: 500, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[2][1]).toEqual({
+    x: 0,
+    y: 500,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 
   expect(stream.rotate(-180)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -534,7 +605,13 @@ test("mouse move when rotated", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[4][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[4][1]).toEqual({ x: 500, y: 1000, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[4][1]).toEqual({
+    x: 500,
+    y: 1000,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 
   expect(stream.rotate(90)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -546,7 +623,13 @@ test("mouse move when rotated", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[6][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[6][1]).toEqual({ x: 0, y: 500, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[6][1]).toEqual({
+    x: 0,
+    y: 500,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 });
 
 test("mouse move when rotated and translated to touch events", () => {
@@ -563,7 +646,7 @@ test("mouse move when rotated and translated to touch events", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Enable emulation
   stream.enableTouchEmulation();
@@ -579,7 +662,12 @@ test("mouse move when rotated and translated to touch events", () => {
   container.dispatchEvent(event);
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 500, y: 1000, id: 0 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 500,
+    y: 1000,
+    id: 0,
+    display_id: 0,
+  });
 
   // Mouse move event at bottom right corner
   event = new PointerEvent("pointermove", {
@@ -593,7 +681,12 @@ test("mouse move when rotated and translated to touch events", () => {
   container.dispatchEvent(event);
   expect(mockFn.mock.calls.length).toEqual(2);
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[1][1]).toEqual({ x: 500, y: 1000, id: 0 });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    x: 500,
+    y: 1000,
+    id: 0,
+    display_id: 0,
+  });
 
   expect(stream.rotate(90)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -606,7 +699,12 @@ test("mouse move when rotated and translated to touch events", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[3][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[3][1]).toEqual({ x: 500, y: 1000, id: 0 });
+  expect(mockFn.mock.calls[3][1]).toEqual({
+    x: 500,
+    y: 1000,
+    id: 0,
+    display_id: 0,
+  });
 
   expect(stream.rotate(180)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -619,7 +717,7 @@ test("mouse move when rotated and translated to touch events", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[5][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[5][1]).toEqual({ x: 0, y: 0, id: 0 });
+  expect(mockFn.mock.calls[5][1]).toEqual({ x: 0, y: 0, id: 0, display_id: 0 });
 
   expect(stream.rotate(-90)).toEqual(true);
   event = new PointerEvent("pointermove", {
@@ -632,7 +730,12 @@ test("mouse move when rotated and translated to touch events", () => {
   event.__defineGetter__("movementY", () => 100);
   container.dispatchEvent(event);
   expect(mockFn.mock.calls[7][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[7][1]).toEqual({ x: 500, y: 1000, id: 0 });
+  expect(mockFn.mock.calls[7][1]).toEqual({
+    x: 500,
+    y: 1000,
+    id: 0,
+    display_id: 0,
+  });
 });
 
 test("touch events when rotated", () => {
@@ -649,7 +752,7 @@ test("touch events when rotated", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   container.dispatchEvent(
     new PointerEvent("pointerdown", {
@@ -661,7 +764,12 @@ test("touch events when rotated", () => {
   );
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 500, y: 1000 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    id: 0,
+    x: 500,
+    y: 1000,
+    display_id: 0,
+  });
 
   expect(stream.rotate(90)).toEqual(true);
   container.dispatchEvent(
@@ -673,7 +781,7 @@ test("touch events when rotated", () => {
     }),
   );
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, x: 0, y: 0 });
+  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, x: 0, y: 0, display_id: 0 });
 
   expect(stream.rotate(180)).toEqual(true);
   container.dispatchEvent(
@@ -687,7 +795,12 @@ test("touch events when rotated", () => {
   expect(mockFn.mock.calls[4][0]).toEqual("input::touch-move");
   // The pionter id will be auto-adjusted to 2 which is the minimal
   // available pointer Id being passed to the Android container
-  expect(mockFn.mock.calls[4][1]).toEqual({ id: 0, x: 500, y: 1000 });
+  expect(mockFn.mock.calls[4][1]).toEqual({
+    id: 0,
+    x: 500,
+    y: 1000,
+    display_id: 0,
+  });
 
   expect(stream.rotate(270)).toEqual(true);
   container.dispatchEvent(
@@ -699,7 +812,7 @@ test("touch events when rotated", () => {
     }),
   );
   expect(mockFn.mock.calls[6][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[6][1]).toEqual({ id: 0, x: 0, y: 0 });
+  expect(mockFn.mock.calls[6][1]).toEqual({ id: 0, x: 0, y: 0, display_id: 0 });
 });
 
 test("single touch events with increment id", () => {
@@ -711,7 +824,7 @@ test("single touch events with increment id", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   let touchEvent = {
     pointerId: 3,
@@ -740,11 +853,21 @@ test("single touch events with increment id", () => {
 
   expect(mockFn.mock.calls.length).toEqual(3);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 0, y: 500 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    id: 0,
+    x: 0,
+    y: 500,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[1][1]).toEqual({ id: 0, x: 250, y: 750 });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    id: 0,
+    x: 250,
+    y: 750,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, last: true });
+  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, last: true, display_id: 0 });
 
   touchEvent = {
     pointerId: 4,
@@ -773,11 +896,21 @@ test("single touch events with increment id", () => {
 
   expect(mockFn.mock.calls.length).toEqual(6);
   expect(mockFn.mock.calls[3][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[3][1]).toEqual({ id: 0, x: 0, y: 500 });
+  expect(mockFn.mock.calls[3][1]).toEqual({
+    id: 0,
+    x: 0,
+    y: 500,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[4][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[4][1]).toEqual({ id: 0, x: 250, y: 750 });
+  expect(mockFn.mock.calls[4][1]).toEqual({
+    id: 0,
+    x: 250,
+    y: 750,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[5][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[5][1]).toEqual({ id: 0, last: true });
+  expect(mockFn.mock.calls[5][1]).toEqual({ id: 0, last: true, display_id: 0 });
 });
 
 test("multiple touch events with increment id", () => {
@@ -789,7 +922,7 @@ test("multiple touch events with increment id", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Multi touch points
   let touchEvent = {
@@ -845,17 +978,41 @@ test("multiple touch events with increment id", () => {
 
   expect(mockFn.mock.calls.length).toEqual(6);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 0, y: 500 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    id: 0,
+    x: 0,
+    y: 500,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[1][1]).toEqual({ id: 1, x: 250, y: 750 });
+  expect(mockFn.mock.calls[1][1]).toEqual({
+    id: 1,
+    x: 250,
+    y: 750,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, x: 100, y: 625 });
+  expect(mockFn.mock.calls[2][1]).toEqual({
+    id: 0,
+    x: 100,
+    y: 625,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[3][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[3][1]).toEqual({ id: 1, x: 375, y: 875 });
+  expect(mockFn.mock.calls[3][1]).toEqual({
+    id: 1,
+    x: 375,
+    y: 875,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[4][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[4][1]).toEqual({ id: 0, last: false });
+  expect(mockFn.mock.calls[4][1]).toEqual({
+    id: 0,
+    last: false,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[5][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[5][1]).toEqual({ id: 1, last: true });
+  expect(mockFn.mock.calls[5][1]).toEqual({ id: 1, last: true, display_id: 0 });
 });
 
 test("ignore touch events outside of video element", () => {
@@ -871,7 +1028,7 @@ test("ignore touch events outside of video element", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   let touchEvent = {
     pointerId: 0,
@@ -914,7 +1071,7 @@ test("trigger pointer events when inputs leave the video container", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Fire 'pointerdown' event to start tracking with the touch point
   let touchEvent = {
@@ -988,15 +1145,30 @@ test("trigger pointer events when inputs leave the video container", () => {
 
   expect(mockFn.mock.calls.length).toEqual(5);
   expect(mockFn.mock.calls[0][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[0][1]).toEqual({ id: 0, x: 125, y: 750 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    id: 0,
+    x: 125,
+    y: 750,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[1][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[1][1]).toEqual({ id: 0, last: true });
+  expect(mockFn.mock.calls[1][1]).toEqual({ id: 0, last: true, display_id: 0 });
   expect(mockFn.mock.calls[2][0]).toEqual("input::touch-start");
-  expect(mockFn.mock.calls[2][1]).toEqual({ id: 0, x: 500, y: 1000 });
+  expect(mockFn.mock.calls[2][1]).toEqual({
+    id: 0,
+    x: 500,
+    y: 1000,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[3][0]).toEqual("input::touch-move");
-  expect(mockFn.mock.calls[3][1]).toEqual({ id: 0, x: 0, y: 500 });
+  expect(mockFn.mock.calls[3][1]).toEqual({
+    id: 0,
+    x: 0,
+    y: 500,
+    display_id: 0,
+  });
   expect(mockFn.mock.calls[4][0]).toEqual("input::touch-end");
-  expect(mockFn.mock.calls[4][1]).toEqual({ id: 0, last: true });
+  expect(mockFn.mock.calls[4][1]).toEqual({ id: 0, last: true, display_id: 0 });
 });
 
 test("control channel is closed when rotate a pointer event", () => {
@@ -1010,7 +1182,7 @@ test("control channel is closed when rotate a pointer event", () => {
   stream._webrtcManager.sendControlMessage = mockFn;
   stream._registerControls();
   stream._onResize();
-  const container = document.getElementById(stream._containerID);
+  const container = document.getElementById(stream._containerIDs[0]);
 
   // Mouse move event at bottom right corner
   let event = new PointerEvent("pointermove", {
@@ -1023,7 +1195,13 @@ test("control channel is closed when rotate a pointer event", () => {
   container.dispatchEvent(event);
   expect(mockFn.mock.calls.length).toEqual(1);
   expect(mockFn.mock.calls[0][0]).toEqual("input::mouse-move");
-  expect(mockFn.mock.calls[0][1]).toEqual({ x: 500, y: 1000, rx: 25, ry: 50 });
+  expect(mockFn.mock.calls[0][1]).toEqual({
+    x: 500,
+    y: 1000,
+    rx: 25,
+    ry: 50,
+    display_id: 0,
+  });
 
   expect(stream.rotate(90)).toEqual(false);
 });

--- a/js/tests/unit/multi-display.test.js
+++ b/js/tests/unit/multi-display.test.js
@@ -1,0 +1,541 @@
+/*
+ * This file is part of Anbox Cloud Streaming SDK
+ *
+ * Copyright 2026 Canonical Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnboxStream } from "./anbox-stream-sdk";
+
+if (!global.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    constructor(type, params) {
+      super(type, params);
+      this.pointerId = params.pointerId;
+      this.pointerType = params.pointerType;
+      this.isPrimary = params.isPrimary;
+    }
+  }
+  global.PointerEvent = PointerEvent;
+}
+
+function makeStream(overrides = {}) {
+  const opts = {
+    connector: { connect() {}, disconnect() {} },
+    controls: { mouse: true, keyboard: false, emulateTouch: false },
+    callbacks: {},
+    ...overrides,
+  };
+  return new AnboxStream(opts);
+}
+
+function makeStreamWithTarget(containerId = "main-container") {
+  return makeStream({ targetElement: containerId });
+}
+
+function addContainer(id, w = 800, h = 600) {
+  const el = document.createElement("div");
+  el.id = id;
+  el.__defineGetter__("clientWidth", () => w);
+  el.__defineGetter__("clientHeight", () => h);
+  el.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: w,
+    height: h,
+    right: w,
+    bottom: h,
+  });
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeFakeStream() {
+  return { id: "fake-stream-" + Math.random() };
+}
+
+beforeEach(() => {
+  global.navigator.__defineGetter__(
+    "userAgent",
+    () =>
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36",
+  );
+  global.navigator.__defineGetter__("maxTouchPoints", () => 5);
+  addContainer("main-container");
+  addContainer("cell-1");
+  addContainer("cell-2");
+  addContainer("cell-3");
+});
+
+afterEach(() => {
+  // Clean up all DOM elements added during the test.
+  document.body.innerHTML = "";
+});
+
+describe("_checkReady", () => {
+  test("fires ready() when primaryDisplayReady and pendingReadyCount is 0", () => {
+    const readyFn = jest.fn();
+    const stream = makeStream({ callbacks: { ready: readyFn } });
+
+    stream._primaryDisplayReady = true;
+    stream._pendingReadyCount = 0;
+    stream._checkReady();
+
+    expect(readyFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire ready() when primaryDisplayReady is false", () => {
+    const readyFn = jest.fn();
+    const stream = makeStream({ callbacks: { ready: readyFn } });
+
+    stream._primaryDisplayReady = false;
+    stream._pendingReadyCount = 0;
+    stream._checkReady();
+
+    expect(readyFn).not.toHaveBeenCalled();
+  });
+
+  test("does not fire ready() when there are pending secondary tracks", () => {
+    const readyFn = jest.fn();
+    const stream = makeStream({ callbacks: { ready: readyFn } });
+
+    stream._primaryDisplayReady = true;
+    stream._pendingReadyCount = 2;
+    stream._checkReady();
+
+    expect(readyFn).not.toHaveBeenCalled();
+  });
+
+  test("fires ready() only after all pending tracks are accounted for", () => {
+    const readyFn = jest.fn();
+    const stream = makeStream({ callbacks: { ready: readyFn } });
+
+    stream._primaryDisplayReady = true;
+    stream._pendingReadyCount = 1;
+    stream._checkReady();
+    expect(readyFn).not.toHaveBeenCalled();
+
+    stream._pendingReadyCount = 0;
+    stream._checkReady();
+    expect(readyFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("_onExtraVideoTrack", () => {
+  test("increments pendingReadyCount and stores stream in pendingVideoTracks", () => {
+    const stream = makeStreamWithTarget();
+    const fakeStream = makeFakeStream();
+
+    expect(stream._pendingReadyCount).toBe(0);
+    stream._onExtraVideoTrack(1, fakeStream);
+
+    expect(stream._pendingReadyCount).toBe(1);
+    expect(stream._pendingVideoTracks[1]).toBe(fakeStream);
+  });
+
+  test("fires videoTrackAdded callback with correct displayId", () => {
+    const videoTrackAdded = jest.fn();
+    const stream = makeStream({
+      targetElement: "main-container",
+      callbacks: { videoTrackAdded },
+    });
+
+    stream._onExtraVideoTrack(2, makeFakeStream());
+
+    expect(videoTrackAdded).toHaveBeenCalledWith(2);
+  });
+
+  test("increments pendingReadyCount for each new extra track", () => {
+    const stream = makeStreamWithTarget();
+
+    stream._onExtraVideoTrack(1, makeFakeStream());
+    stream._onExtraVideoTrack(2, makeFakeStream());
+    stream._onExtraVideoTrack(3, makeFakeStream());
+
+    expect(stream._pendingReadyCount).toBe(3);
+    expect(stream._pendingVideoTracks[1]).toBeDefined();
+    expect(stream._pendingVideoTracks[2]).toBeDefined();
+    expect(stream._pendingVideoTracks[3]).toBeDefined();
+  });
+
+  test("updates srcObject if video element already exists in DOM", () => {
+    const stream = makeStreamWithTarget();
+    const fakeStream1 = makeFakeStream();
+    const fakeStream2 = makeFakeStream();
+
+    // Pre-create the video element in DOM.
+    const videoEl = document.createElement("video");
+    videoEl.id = `${stream._videoID}-display-1`;
+    document.body.appendChild(videoEl);
+
+    stream._onExtraVideoTrack(1, fakeStream1);
+    // pendingReadyCount should NOT increment since video already exists.
+    expect(stream._pendingReadyCount).toBe(0);
+
+    stream._onExtraVideoTrack(1, fakeStream2);
+    expect(videoEl.srcObject).toBe(fakeStream2);
+  });
+});
+
+describe("_createExtraVideoElement", () => {
+  test("creates a video element with the given id and stream", () => {
+    const stream = makeStreamWithTarget();
+    const fakeStream = makeFakeStream();
+
+    const video = stream._createExtraVideoElement("my-video-id", fakeStream);
+
+    expect(video.tagName).toBe("VIDEO");
+    expect(video.id).toBe("my-video-id");
+    expect(video.srcObject).toBe(fakeStream);
+    expect(video.autoplay).toBe(true);
+    expect(video.muted).toBe(true);
+    expect(video.controls).toBe(false);
+    expect(video.playsInline).toBe(true);
+    expect(video.style.position).toBe("absolute");
+  });
+});
+
+describe("_updateGridColumns", () => {
+  function makeGrid(cellCount) {
+    const container = document.createElement("div");
+    for (let i = 0; i < cellCount; i++) {
+      const cell = document.createElement("div");
+      cell.className = "anbox-stream-cell";
+      container.appendChild(cell);
+    }
+    return container;
+  }
+
+  test("1 display: 1 column, 1 row", () => {
+    const stream = makeStreamWithTarget();
+    const container = makeGrid(1);
+    stream._updateGridColumns(container);
+    expect(container.style.gridTemplateColumns).toBe("repeat(1, 1fr)");
+    expect(container.style.gridTemplateRows).toBe("repeat(1, 1fr)");
+  });
+
+  test("2 displays: 2 columns, 1 row", () => {
+    const stream = makeStreamWithTarget();
+    const container = makeGrid(2);
+    stream._updateGridColumns(container);
+    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(container.style.gridTemplateRows).toBe("repeat(1, 1fr)");
+  });
+
+  test("3 displays: 2 columns, 2 rows", () => {
+    const stream = makeStreamWithTarget();
+    const container = makeGrid(3);
+    stream._updateGridColumns(container);
+    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(container.style.gridTemplateRows).toBe("repeat(2, 1fr)");
+  });
+
+  test("4 displays: 2 columns, 2 rows", () => {
+    const stream = makeStreamWithTarget();
+    const container = makeGrid(4);
+    stream._updateGridColumns(container);
+    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
+    expect(container.style.gridTemplateRows).toBe("repeat(2, 1fr)");
+  });
+});
+
+describe("attachDisplay (legacy mode)", () => {
+  test("attachDisplay(0) is a no-op when targetElement is set", () => {
+    const stream = makeStreamWithTarget("main-container");
+
+    // Should return without creating video or modifying anything.
+    stream._pendingVideoTracks[0] = makeFakeStream();
+    stream.attachDisplay(0, "cell-1");
+
+    // In legacy mode the pending track for display 0 is NOT consumed.
+    expect(stream._pendingVideoTracks[0]).toBeDefined();
+    expect(document.querySelector("#cell-1 video")).toBeNull();
+  });
+});
+
+describe("attachDisplay (dynamic mode)", () => {
+  test("attachDisplay(0, containerId) injects primary video into container", () => {
+    const stream = makeStream(); // no targetElement
+    const fakeStream = makeFakeStream();
+    stream._pendingVideoTracks[0] = fakeStream;
+
+    stream.attachDisplay(0, "main-container");
+
+    const video = document.getElementById(stream._videoID);
+    expect(video).not.toBeNull();
+    expect(video.srcObject).toBe(fakeStream);
+    expect(stream._containerIDs[0]).toBe("main-container");
+    expect(stream._pendingVideoTracks[0]).toBeUndefined();
+  });
+
+  test("attachDisplay(1, containerId) injects secondary video and registers input handlers", () => {
+    const stream = makeStreamWithTarget("main-container");
+    const fakeStream = makeFakeStream();
+    stream._pendingVideoTracks[1] = fakeStream;
+
+    stream.attachDisplay(1, "cell-1");
+
+    const videoId = `${stream._videoID}-display-1`;
+    const video = document.getElementById(videoId);
+    expect(video).not.toBeNull();
+    expect(video.srcObject).toBe(fakeStream);
+    expect(stream._pendingVideoTracks[1]).toBeUndefined();
+    expect(stream._containerIDs[1]).toBe("cell-1");
+
+    // Input handlers should be registered for display 1 on the cell container.
+    const entry = stream._displayEventListeners[1];
+    expect(entry).toBeDefined();
+    expect(entry.container).toBe(document.getElementById("cell-1"));
+    expect(typeof entry.handlers.pointermove).toBe("function");
+    expect(typeof entry.handlers.pointerdown).toBe("function");
+    expect(typeof entry.handlers.pointerup).toBe("function");
+    expect(typeof entry.handlers.pointercancel).toBe("function");
+    expect(typeof entry.handlers.mousewheel).toBe("function");
+  });
+
+  test("attachDisplay warns and returns when no pending stream exists", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const stream = makeStreamWithTarget("main-container");
+
+    stream.attachDisplay(1, "cell-1");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no pending stream"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  test("attachDisplay logs error and returns when container not found", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const stream = makeStreamWithTarget("main-container");
+    stream._pendingVideoTracks[1] = makeFakeStream();
+
+    stream.attachDisplay(1, "nonexistent-container");
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("container #nonexistent-container not found"),
+    );
+    errorSpy.mockRestore();
+  });
+
+  test("attachDisplay extends _displayStates for new track index", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._pendingVideoTracks[2] = makeFakeStream();
+
+    stream.attachDisplay(2, "cell-2");
+
+    expect(2 in stream._displayStates).toBe(true);
+    expect(stream._displayStates[2]).toBeDefined();
+    expect(stream._displayStates[2].activeTouchPointers).toEqual([]);
+  });
+});
+
+describe("per-display input routing", () => {
+  function setupTwoDisplayStream() {
+    const stream = makeStreamWithTarget("main-container");
+
+    // Set up display 0 video.
+    const video0 = document.createElement("video");
+    video0.id = stream._videoID;
+    video0.__defineGetter__("videoWidth", () => 800);
+    video0.__defineGetter__("videoHeight", () => 600);
+    document.getElementById("main-container").appendChild(video0);
+    stream._onResize();
+
+    // Simulate extra track arriving for display 1.
+    const fakeStream = makeFakeStream();
+    stream._pendingVideoTracks[1] = fakeStream;
+    stream.attachDisplay(1, "cell-1");
+
+    const video1 = document.getElementById(`${stream._videoID}-display-1`);
+    if (video1) {
+      video1.__defineGetter__("videoWidth", () => 400);
+      video1.__defineGetter__("videoHeight", () => 300);
+      video1.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 400,
+        height: 300,
+        right: 400,
+        bottom: 300,
+      });
+    }
+
+    // In multi-display mode, display 0 also uses getBoundingClientRect.
+    // Mock its rect so pointer events are not silently dropped.
+    video0.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 800,
+      height: 600,
+      right: 800,
+      bottom: 600,
+    });
+
+    return stream;
+  }
+
+  test("pointer events are routed with the correct display_id for each container", () => {
+    const stream = setupTwoDisplayStream();
+    const mockSend = jest.fn(() => true);
+    stream._webrtcManager = {
+      _isControlChannelOpen: true,
+      sendControlMessage: mockSend,
+      stop: jest.fn(),
+    };
+
+    stream._registerInputHandlers(0, document.getElementById("main-container"));
+    stream._registerInputHandlers(1, document.getElementById("cell-1"));
+
+    // Event on display 1 container must carry display_id: 1.
+    document.getElementById("cell-1").dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerType: "mouse",
+        clientX: 100,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 0,
+      }),
+    );
+    expect(mockSend).toHaveBeenCalledWith(
+      "input::mouse-button",
+      expect.objectContaining({ display_id: 1 }),
+    );
+
+    mockSend.mockClear();
+
+    // Event on display 0 container must carry display_id: 0.
+    document.getElementById("main-container").dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerType: "mouse",
+        clientX: 100,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 0,
+      }),
+    );
+    expect(mockSend).toHaveBeenCalledWith(
+      "input::mouse-button",
+      expect.objectContaining({ display_id: 0 }),
+    );
+  });
+});
+
+describe("_removeMedia", () => {
+  test("fires videoTrackRemoved for each attached display in reverse order", () => {
+    const removed = [];
+    const stream = makeStream({
+      targetElement: "main-container",
+      callbacks: { videoTrackRemoved: (i) => removed.push(i) },
+    });
+
+    // Simulate 3 displays attached.
+    stream._containerIDs = { 0: "main-container", 1: "cell-1", 2: "cell-2" };
+
+    stream._removeMedia();
+
+    expect(removed).toEqual([2, 1, 0]);
+  });
+
+  test("resets multiDisplay state flags", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._multiDisplayActive = true;
+    stream._primaryDisplayReady = true;
+    stream._pendingReadyCount = 3;
+    stream._pendingVideoTracks = { 1: makeFakeStream() };
+
+    stream._removeMedia();
+
+    expect(stream._multiDisplayActive).toBe(false);
+    expect(stream._primaryDisplayReady).toBe(false);
+    expect(stream._pendingReadyCount).toBe(0);
+    expect(stream._pendingVideoTracks).toEqual({});
+  });
+
+  test("removes secondary video elements from DOM", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._containerIDs = { 0: "main-container", 1: "cell-1", 2: "cell-2" };
+
+    // Add secondary video elements to DOM.
+    const v1 = document.createElement("video");
+    v1.id = `${stream._videoID}-display-1`;
+    document.body.appendChild(v1);
+    const v2 = document.createElement("video");
+    v2.id = `${stream._videoID}-display-2`;
+    document.body.appendChild(v2);
+
+    stream._removeMedia();
+
+    expect(document.getElementById(`${stream._videoID}-display-1`)).toBeNull();
+    expect(document.getElementById(`${stream._videoID}-display-2`)).toBeNull();
+  });
+
+  test("resets _containerIDs and _displayStates to initial values", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._containerIDs = { 0: "main-container", 1: "cell-1" };
+
+    stream._removeMedia();
+
+    expect(stream._containerIDs).toEqual({ 0: "main-container" });
+    // Should have one display state entry (for display 0).
+    expect(0 in stream._displayStates).toBe(true);
+    expect(1 in stream._displayStates).toBe(false);
+  });
+
+  test("resets _containerIDs to empty in fully dynamic mode", () => {
+    const stream = makeStream(); // no targetElement
+    stream._containerIDs = { 0: "cell-1", 1: "cell-2" };
+
+    stream._removeMedia();
+
+    expect(stream._containerIDs).toEqual({});
+    expect(stream._displayStates).toEqual({});
+  });
+});
+
+describe("_displayStates initialisation", () => {
+  test("legacy mode initialises one state entry for display 0", () => {
+    const stream = makeStreamWithTarget("main-container");
+
+    expect(0 in stream._displayStates).toBe(true);
+    const s = stream._displayStates[0];
+    expect(s.dimensions).toBeNull();
+    expect(s.activeTouchPointers).toEqual([]);
+    expect(s.pointerIdsMapper).toEqual({});
+    expect(s.primaryTouchId).toBe(0);
+    expect(s.pointersOutofBounds).toEqual({});
+  });
+
+  test("fully dynamic mode initialises an empty _displayStates object", () => {
+    const stream = makeStream(); // no targetElement
+
+    expect(stream._displayStates).toEqual({});
+    expect(stream._containerIDs).toEqual({});
+  });
+});
+
+describe("videoTrackAdded and videoTrackRemoved callbacks", () => {
+  test("videoTrackAdded fires with displayId when extra track arrives", () => {
+    const added = [];
+    const stream = makeStream({
+      targetElement: "main-container",
+      callbacks: { videoTrackAdded: (i) => added.push(i) },
+    });
+
+    stream._onExtraVideoTrack(1, makeFakeStream());
+    stream._onExtraVideoTrack(2, makeFakeStream());
+
+    expect(added).toEqual([1, 2]);
+  });
+});

--- a/js/tests/unit/sdk.test.js
+++ b/js/tests/unit/sdk.test.js
@@ -71,9 +71,15 @@ afterEach(() => {
 test("SDK properly checks constructor options", () => {
   expect(() => new AnboxStream()).toThrow("missing options");
 
+  // targetElement is optional since 1.31.0.
+  // null/omitted is valid for multi-display case.
   sdkOptions.targetElement = null;
+  expect(() => new AnboxStream(sdkOptions)).not.toThrow();
+
+  // Non-string targetElement is rejected
+  sdkOptions.targetElement = ["display0", "display1"];
   expect(() => new AnboxStream(sdkOptions)).toThrow(
-    "missing targetElement parameter",
+    "targetElement must be a string",
   );
 
   sdkOptions.targetElement = "nonexistent";
@@ -155,7 +161,7 @@ test("Video container with no size specified", () => {
   expect(() => new AnboxStream(options)).not.toThrow();
   expect(console.error).toHaveBeenCalledWith(
     expect.stringContaining(
-      "AnboxStream: video container element misses size. Please see https://canonical.com/anbox-cloud/docs/tutorial/stream-client",
+      '[AnboxStream] video container element "baz" misses size. Please see https://canonical.com/anbox-cloud/docs/tutorial/stream-client',
     ),
   );
   global.console.error.mockRestore();
@@ -215,13 +221,13 @@ test("video element should take all available space", () => {
   container.appendChild(video);
 
   stream._onResize();
-  let dimensions = stream._dimensions;
+  let dimensions = stream._displayStates[0].dimensions;
   expect(dimensions.playerWidth).toEqual(1000);
   expect(dimensions.playerHeight).toEqual(2000);
 
   // Perform a rotation
   expect(stream.rotate(90)).toEqual(true);
-  dimensions = stream._dimensions;
+  dimensions = stream._displayStates[0].dimensions;
 
   expect(video.style.transform).toEqual("rotate(90deg)");
   expect(stream._webrtcManager.sendControlMessage).toHaveBeenCalledWith(
@@ -631,7 +637,7 @@ test("player respects the vertical aligment settings", () => {
     container.appendChild(video);
 
     stream._onResize();
-    let dimensions = stream._dimensions;
+    let dimensions = stream._displayStates[0].dimensions;
     expect(dimensions.playerWidth).toEqual(2000);
     expect(dimensions.playerHeight).toEqual(1000);
 


### PR DESCRIPTION
## Done

This is the initial multi-display support in the JS SDK, which enabling the
WebRTC manager to handle multiple simultaneous video tracks, touch 
tracking and input event routing per-display.

The targetElement (video container) is now optional, preserved for backward 
compatibility in legacy single-display mode. 

Two new callbacks
- videoTrackAdded
- videoTrackRemoved

are added in the JS SDK to support dynamical display attachment(multi-display mode)
via attachDisplay() API.

## QA

1. Enable newly added tests cases pass
2. For the real e2e testing, please try out the [webrtc_multiple_display](https://github.com/adglkh/ams/tree/webrtc_multiple_display), which has this JS SDK mirrored in the dashboard UI
    - Launch an instance multi displays
          $ amc launch resolute:android16-cf:amd64 --enable-streaming --devmode -c 4 -m 8GB --name test-multi-display \\
             --display=width=1280,height=720,fps=60 \\
             --display=width=480,height=640,dpi=120 \\
             --display=width=800,height=600,fps=30
      Once the instance is up and running, ensure each display are present on the UI properly
    - In the meanwhile, present different apps in different displays within the instance
        $ amc exec <instance_id> --  adb shell am start-activity -W -n com.android.dialer/.main.impl.MainActivity --display 2
        $ amc exec <instance_id> --  adb shell am start-activity -W -n com.android.gallery3d/com.android.gallery3d.app.Gallery --display 3 

## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-4542

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: yes, in the 1.31.0 release announcement.