### PR TITLE
Fix SDK mouse buttons matching

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1458,13 +1458,15 @@ class AnboxStream {
    */
   _getPressedButton(event) {
     switch (event.button) {
-      case 0: // no button
+      case 0: // main button (left)
         return 1;
-      case 1: // primary button (left click)
-        return 2;
-      case 2: // secondary button (right click)
+      case 1: // auxiliary button (middle)
         return 3;
-      case 4: // auxiliary button (middle click usually) - NOT CURRENTLY SUPPORTED BY ANBOX
+      case 2: // secondary button (right)
+        return 2;
+      case 3: // browser back
+        return 4;
+      case 4: // browser forward
         return 5;
       default:
         return 0;


### PR DESCRIPTION
## Done

The SDK seemingly always sent the wrong button map to the platform (and it wasn't consistent with what we have there either).

This is based on https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button

## QA

Build SDK.

## JIRA / Launchpad bug

Contributes to [AC-4829](https://warthogs.atlassian.net/browse/AC-4829)

## Documentation

This is, arguably, mostly internal stuff, so it should be fine to fix silently.

[AC-4829]: https://warthogs.atlassian.net/browse/AC-4829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ