### PR TITLE
Track per-display video statistics for multi video track sessions

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -4056,6 +4056,10 @@ class AnboxWebRTCManager {
   }
 
   _startStatsUpdater() {
+    // _onRtcTrack is invoked once per additional video/audio track.
+    // Guard against overlapping timers for multi-track sessions.
+    window.clearInterval(this._statsTimerId);
+
     let pcConf = this._pc.getConfiguration();
     if (pcConf) {
       if ("sdpSemantics" in pcConf)

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -4270,38 +4270,37 @@ class AnboxWebRTCManager {
     insertStat("localCandidateType", this._stats.network.localCandidateType);
     insertStat("remoteCandidateType", this._stats.network.remoteCandidateType);
 
-    insertHeader("Video");
-    insertStat("codec", this._stats.video.codec);
-    insertStat("bandWidth", mbits_format(this._stats.video.bandwidthMbit));
-    insertStat(
-      "totalBytesReceived",
-      mb_format(this._stats.video.totalBytesReceived),
-    );
-    insertStat("fps", this._stats.video.fps);
-    insertStat("decodeTime", ms_format(this._stats.video.decodeTime));
-    insertStat("jitter", ms_format(this._stats.video.jitter));
-    insertStat(
-      "avgJitterBufferDelay",
-      ms_format(this._stats.video.avgJitterBufferDelay),
-    );
-    insertStat("packetsReceived", this._stats.video.packetsReceived);
-    insertStat("packetsLost", this._stats.video.packetsLost);
-    insertStat("framesDropped", this._stats.video.framesDropped);
-    insertStat("framesDecoded", this._stats.video.framesDecoded);
-    insertStat("framesReceived", this._stats.video.framesReceived);
-    insertStat("keyFramesDecoded", this._stats.video.keyFramesDecoded);
-    insertStat(
-      "totalAssemblyTime",
-      s_format(this._stats.video.totalAssemblyTime),
-    );
-    insertStat(
-      "framesAssembledFromMultiplePackets",
-      this._stats.video.framesAssembledFromMultiplePackets,
-    );
-    insertStat("pliCount", this._stats.video.pliCount);
-    insertStat("firCount", this._stats.video.firCount);
-    insertStat("nackCount", this._stats.video.nackCount);
-    insertStat("qpSum", this._stats.video.qpSum);
+    // One section per received video track, sorted by display id
+    // so the primary display always comes first.
+    const displayIds = Object.keys(this._stats.videoTracks)
+      .map(Number)
+      .sort((a, b) => a - b);
+    for (const displayId of displayIds) {
+      const v = this._stats.videoTracks[displayId];
+      insertHeader(`Video (display ${displayId})`);
+      insertStat("codec", v.codec);
+      insertStat("bandWidth", mbits_format(v.bandwidthMbit));
+      insertStat("totalBytesReceived", mb_format(v.totalBytesReceived));
+      insertStat("fps", v.fps);
+      insertStat("decodeTime", ms_format(v.decodeTime));
+      insertStat("jitter", ms_format(v.jitter));
+      insertStat("avgJitterBufferDelay", ms_format(v.avgJitterBufferDelay));
+      insertStat("packetsReceived", v.packetsReceived);
+      insertStat("packetsLost", v.packetsLost);
+      insertStat("framesDropped", v.framesDropped);
+      insertStat("framesDecoded", v.framesDecoded);
+      insertStat("framesReceived", v.framesReceived);
+      insertStat("keyFramesDecoded", v.keyFramesDecoded);
+      insertStat("totalAssemblyTime", s_format(v.totalAssemblyTime));
+      insertStat(
+        "framesAssembledFromMultiplePackets",
+        v.framesAssembledFromMultiplePackets,
+      );
+      insertStat("pliCount", v.pliCount);
+      insertStat("firCount", v.firCount);
+      insertStat("nackCount", v.nackCount);
+      insertStat("qpSum", v.qpSum);
+    }
 
     insertHeader("Audio Output");
     insertStat("codec", this._stats.audioOutput.codec);
@@ -4648,7 +4647,7 @@ class AnboxStreamCanvas {
     // Disable the ESLint rule for better readability
     /* eslint-disable */
     const vertices = [
-      // postion   // texture coordinate
+      // position  // texture coordinate
       -1.0, 1.0,   0.0, 1.0,
       -1.0, -1.0,  0.0, 0.0,
       1.0,  -1.0,  1.0, 0.0,

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -2841,7 +2841,7 @@ class AnboxWebRTCManager {
     this._audioStream = null;
     this._audioInputStream = null;
     this._videoInputStream = null;
-    this._video_codec_id = null;
+    this._video_codec_ids = {};
     this._audioOutput_codec_id = null;
     this._audioInput_codec_id = null;
     // All video streams keyed by display id
@@ -2893,27 +2893,6 @@ class AnboxWebRTCManager {
         localCandidateType: "",
         remoteCandidateType: "",
       },
-      video: {
-        bandwidthMbit: 0,
-        totalBytesReceived: 0,
-        fps: 0,
-        decodeTime: 0,
-        jitter: 0,
-        avgJitterBufferDelay: 0,
-        packetsReceived: 0,
-        packetsLost: 0,
-        framesDropped: 0,
-        framesDecoded: 0,
-        framesReceived: 0,
-        keyFramesDecoded: 0,
-        totalAssemblyTime: 0,
-        pliCount: 0,
-        firCount: 0,
-        nackCount: 0,
-        qpSum: 0,
-        framesAssembledFromMultiplePackets: 0,
-        codec: "",
-      },
       audioOutput: {
         bandwidthMbit: 0,
         totalBytesReceived: 0,
@@ -2935,9 +2914,13 @@ class AnboxWebRTCManager {
         },
       },
     };
+    // `video` is an alias of `videoTracks[0]` kept for the backward compatibility, while
+    // new multi-display consumers can look up any track through `videoTracks[displayId]`.
+    this._stats.video = this._initVideoTrackStats();
+    this._stats.videoTracks = { 0: this._stats.video };
 
     this._lastReport = {
-      video: {},
+      videoTracks: {},
       audioOutput: {},
       audioInput: {},
       canvas: {},
@@ -3223,7 +3206,10 @@ class AnboxWebRTCManager {
   }
 
   /**
-   * video: Statistics on the received video track.
+   * video: Statistics on the received video track of display 0 (the primary
+   *   display). This field is kept for backward compatibility and is always
+   *   equal to `videoTracks[0]`. New code that needs per-display statistics
+   *   (multi video track sessions) should use `videoTracks` instead.
    *   bandwidthMbit: Video traffic received in mbits/s.
    *   totalBytesReceived: Total cumulated bytes received for the current session.
    *   fps: Current frames per second.
@@ -3232,6 +3218,9 @@ class AnboxWebRTCManager {
    *   avgJitterBufferDelay: Average variance in packet delay in seconds. A high jitter can mean an unstable or congested network.
    *   packetsReceived: Total number of packets received.
    *   packetsLost: Total number of packets lost.
+   * videoTracks: Statistics on every received video track, keyed by display id
+   *   (0 for the primary display, 1+ for additional displays in multi video
+   *   track sessions). Each entry has the same struct as `video` above.
    * network: Information about the network and WebRTC connections.
    *   currentRtt: Current round trip time in seconds.
    *   networkType: Type of network in use. (NOTE: It's deprecated to preserve the privacy) Can be one of the following:
@@ -3775,22 +3764,7 @@ class AnboxWebRTCManager {
   _onRtcTrack(event) {
     const kind = event.track.kind;
     if (kind === "video") {
-      // The server assigns each video track the label "video_N" (where N is the
-      // display id) when adding video transceiver. On client side, parsing it
-      // here from MediaStreamTrack.id gives us the correct display id.
-      // NOTE: older images use the legacy track name "video", hence treat
-      // those as primary display for backward compatibility.
-      let displayId;
-      const m = event.track.id.match(/^video_(\d+)$/);
-      if (m) {
-        displayId = parseInt(m[1], 10);
-      } else if (event.track.id === "video") {
-        displayId = 0;
-      } else {
-        console.error(`failed to parse display id: ${event.track.id}`);
-        return;
-      }
-
+      const displayId = this._displayIdFromTrackId(event.track.id);
       // Wrap the single track in its own MediaStream. All video tracks share
       // the same stream_id on the server side so event.streams[0] is the same
       // MediaStream object for every track. A per-track MediaStream guarantees
@@ -4044,6 +4018,43 @@ class AnboxWebRTCManager {
     this._audioInputStream = stream;
   }
 
+  _initVideoTrackStats() {
+    return {
+      bandwidthMbit: 0,
+      totalBytesReceived: 0,
+      fps: 0,
+      decodeTime: 0,
+      jitter: 0,
+      avgJitterBufferDelay: 0,
+      packetsReceived: 0,
+      packetsLost: 0,
+      framesDropped: 0,
+      framesDecoded: 0,
+      framesReceived: 0,
+      keyFramesDecoded: 0,
+      totalAssemblyTime: 0,
+      pliCount: 0,
+      firCount: 0,
+      nackCount: 0,
+      qpSum: 0,
+      framesAssembledFromMultiplePackets: 0,
+      codec: "",
+    };
+  }
+
+  // The server assigns each video track the label "video_N" (where N is the
+  // display id) when adding video transceiver. On client side, parsing it
+  // here from MediaStreamTrack.id gives us the correct display id.
+  // NOTE: older images use the legacy track name "video", hence treat
+  // those as primary display for backward compatibility.
+  _displayIdFromTrackId(trackId) {
+    if (typeof trackId === "string") {
+      const m = trackId.match(/^video_(\d+)$/);
+      if (m) return parseInt(m[1], 10);
+    }
+    return 0;
+  }
+
   _startStatsUpdater() {
     let pcConf = this._pc.getConfiguration();
     if (pcConf) {
@@ -4088,7 +4099,10 @@ class AnboxWebRTCManager {
         report.type === "inbound-rtp" &&
         (report.kind === "video" || report.mediaType === "video")
       ) {
-        let v = this._stats.video;
+        const displayId = this._displayIdFromTrackId(report.trackIdentifier);
+        if (!(displayId in this._stats.videoTracks))
+          this._stats.videoTracks[displayId] = this._initVideoTrackStats();
+        let v = this._stats.videoTracks[displayId];
         v.fps = report.framesPerSecond;
         v.packetsLost = report.packetsLost;
         v.packetsReceived = report.packetsReceived;
@@ -4107,17 +4121,18 @@ class AnboxWebRTCManager {
         v.avgJitterBufferDelay =
           report.jitterBufferDelay / report.jitterBufferEmittedCount;
         v.totalBytesReceived = report.bytesReceived;
-        this._video_codec_id = report.codecId;
+        this._video_codec_ids[displayId] = report.codecId;
+        const lastReport = this._lastReport.videoTracks[displayId];
         const elapsedInSec = Math.round(
           (report.timestamp -
-            (this._lastReport.video?.timestamp || report.timestamp - 1000)) /
+            (lastReport?.timestamp || report.timestamp - 1000)) /
             1000.0,
         );
         v.bandwidthMbit = bytes_to_mbits(
-          report.bytesReceived - (this._lastReport.video?.bytesReceived || 0),
+          report.bytesReceived - (lastReport?.bytesReceived || 0),
           elapsedInSec,
         );
-        this._lastReport.video = report;
+        this._lastReport.videoTracks[displayId] = report;
         if (report.framesDecoded !== 0)
           v.decodeTime = report.totalDecodeTime / report.framesDecoded;
       } else if (
@@ -4191,8 +4206,12 @@ class AnboxWebRTCManager {
         const media_info = report.mimeType.split("/");
         if (media_info.length < 2) return;
         const [media_type, media_codec] = media_info;
-        if (report.id == this._video_codec_id && media_type == "video")
-          this._stats.video.codec = media_codec;
+        if (media_type == "video") {
+          for (const displayId of Object.keys(this._video_codec_ids)) {
+            if (report.id == this._video_codec_ids[displayId])
+              this._stats.videoTracks[displayId].codec = media_codec;
+          }
+        }
         if (report.id == this._audioOutput_codec_id && media_type == "audio")
           this._stats.audioOutput.codec = media_codec;
         if (report.id == this._audioInput_codec_id && media_type == "audio")

--- a/js/tests/unit/stats.test.js
+++ b/js/tests/unit/stats.test.js
@@ -374,6 +374,42 @@ test("stats overlay is properly displayed", () => {
   expect(overlay.innerHTML).toContain("bandWidth: 8.00 Mbit/s");
 });
 
+test("stats overlay shows a section per display in multi video track sessions", () => {
+  const mgr = new AnboxStream(sdkOptions);
+  const overlayContainer = document.createElement("div");
+  overlayContainer.id = "stat-overlay-multi";
+  document.body.appendChild(overlayContainer);
+
+  mgr._webrtcManager._statsOverlayID = overlayContainer.id;
+  mgr._webrtcManager.showStatsOverlay();
+  mgr._webrtcManager._processRawStats([
+    {
+      timestamp: 1234,
+      type: "inbound-rtp",
+      kind: "video",
+      trackIdentifier: "video_0",
+      framesPerSecond: 60,
+      bytesReceived: 1000000,
+      totalAssemblyTime: 0,
+    },
+    {
+      timestamp: 1234,
+      type: "inbound-rtp",
+      kind: "video",
+      trackIdentifier: "video_1",
+      framesPerSecond: 30,
+      bytesReceived: 500000,
+      totalAssemblyTime: 0,
+    },
+  ]);
+  mgr._webrtcManager._refreshStatsOverlay();
+  const overlay = document.getElementById(overlayContainer.id + "_child");
+  expect(overlay.innerHTML).toContain("Video (display 0)");
+  expect(overlay.innerHTML).toContain("Video (display 1)");
+  expect(overlay.innerHTML).toContain("fps: 60");
+  expect(overlay.innerHTML).toContain("fps: 30");
+});
+
 test("per-display video stats are tracked separately for multi video track sessions", () => {
   const mgr = new AnboxStream(sdkOptions);
 

--- a/js/tests/unit/stats.test.js
+++ b/js/tests/unit/stats.test.js
@@ -373,3 +373,53 @@ test("stats overlay is properly displayed", () => {
   expect(overlay.innerHTML).toContain("totalBytesReceived: 1.00 MB");
   expect(overlay.innerHTML).toContain("bandWidth: 8.00 Mbit/s");
 });
+
+test("per-display video stats are tracked separately for multi video track sessions", () => {
+  const mgr = new AnboxStream(sdkOptions);
+
+  const timestamp = performance.now();
+  const data = [
+    {
+      timestamp,
+      type: "inbound-rtp",
+      kind: "video",
+      trackIdentifier: "video_0",
+      framesPerSecond: 30,
+      packetsReceived: 10,
+      bytesReceived: 1000,
+    },
+    {
+      timestamp,
+      type: "inbound-rtp",
+      kind: "video",
+      trackIdentifier: "video_1",
+      framesPerSecond: 60,
+      packetsReceived: 20,
+      bytesReceived: 2000,
+    },
+    {
+      timestamp,
+      type: "inbound-rtp",
+      kind: "video",
+      trackIdentifier: "video_2",
+      framesPerSecond: 15,
+      packetsReceived: 5,
+      bytesReceived: 500,
+    },
+  ];
+
+  mgr._webrtcManager._processRawStats(data);
+  const stats = mgr._webrtcManager.getStats();
+
+  // The legacy `video` field keeps reporting primary display and
+  // stays in sync with `videoTracks[0]` for backward compatibility.
+  expect(stats.video.fps).toEqual(30);
+  expect(stats.video.packetsReceived).toEqual(10);
+  expect(stats.video).toBe(stats.videoTracks[0]);
+
+  // Each additional display gets its own independent stats entry.
+  expect(stats.videoTracks[1].fps).toEqual(60);
+  expect(stats.videoTracks[1].packetsReceived).toEqual(20);
+  expect(stats.videoTracks[2].fps).toEqual(15);
+  expect(stats.videoTracks[2].packetsReceived).toEqual(5);
+});


### PR DESCRIPTION
## Done

This change introduces `videoTracks` to track inbound RTP statistics
separately for each display ID, and old `_stats.video` field now
is an alias pointing to `videoTracks[0]` to preserve backward
compatibility for existing consumers.

## QA

1. Import the JS SDK into a stream client
2. Register the statsUpdate callback function to the AnboxStream
```
        stream = new AnboxStream({
          connector: connector,
          ...
          callbacks: {
            statsUpdated: s => {
              console.log(s)
            },
            ready: () => {
            ...
```

4. Launch an instance with multi displays form euphotic image:
   $ amc launch resolute:android16-cf:amd64 --enable-streaming --devmode -c 4 -m 8GB --name test-multi-display \
    --display=width=1280,height=720,fps=60 \
    --display=width=480,height=640,dpi=120 \
    --display=width=800,height=600,fps=30  
5. Once the stream is up and running, check the console and see the stats output, `video` field of the stats output would show the stats for the primary display for the backward comp, and `videoTracks` field of the stats output would show stas per display.  
    <details> 
    {
        "rtcConfig": {
            "sdpSemantics": "",
            "rtcpMuxPolicy": "require",
            "bundlePolicy": "balanced",
            "iceTransportPolicy": "all",
            "iceCandidatePoolSize": 0
        },
        "network": {
            "currentRtt": 0,
            "networkType": "unknown",
            "transportType": "udp",
            "localCandidateType": "host",
            "remoteCandidateType": "prflx"
        },
        "audioOutput": {
            "bandwidthMbit": 0,
            "totalBytesReceived": 0,
            "totalSamplesReceived": 0,
            "jitter": 0,
            "avgJitterBufferDelay": 0,
            "packetsReceived": 0,
            "packetsLost": 0,
            "codec": ""
        },
        "audioInput": {
            "bandwidthMbit": 0,
            "totalBytesSent": 346,
            "codec": "opus"
        },
        "experimental": {
            "canvas": {
                "fps": 0
            }
        },
        "video": {
            "bandwidthMbit": 0.1138,
            "totalBytesReceived": 282028,
            "fps": 3,
            "decodeTime": 0.0016992264150943396,
            "jitter": 0,
            "avgJitterBufferDelay": 0.0003613207547169811,
            "packetsReceived": 291,
            "packetsLost": 0,
            "framesDropped": 0,
            "framesDecoded": 53,
            "framesReceived": 53,
            "keyFramesDecoded": 1,
            "totalAssemblyTime": 0.011916,
            "pliCount": 0,
            "firCount": 0,
            "nackCount": 0,
            "qpSum": 383,
            "framesAssembledFromMultiplePackets": 51,
            "codec": "VP8"
        },
        "videoTracks": {
            "0": {
                "bandwidthMbit": 0.1138,
                "totalBytesReceived": 282028,
                "fps": 3,
                "decodeTime": 0.0016992264150943396,
                "jitter": 0,
                "avgJitterBufferDelay": 0.0003613207547169811,
                "packetsReceived": 291,
                "packetsLost": 0,
                "framesDropped": 0,
                "framesDecoded": 53,
                "framesReceived": 53,
                "keyFramesDecoded": 1,
                "totalAssemblyTime": 0.011916,
                "pliCount": 0,
                "firCount": 0,
                "nackCount": 0,
                "qpSum": 383,
                "framesAssembledFromMultiplePackets": 51,
                "codec": "VP8"
            },
            "1": {
                "bandwidthMbit": 0.009215999999999998,
                "totalBytesReceived": 36049,
                "fps": 2,
                "decodeTime": 0.00030506,
                "jitter": 0,
                "avgJitterBufferDelay": 0.00026664,
                "packetsReceived": 57,
                "packetsLost": 0,
                "framesDropped": 0,
                "framesDecoded": 50,
                "framesReceived": 50,
                "keyFramesDecoded": 1,
                "totalAssemblyTime": 0.00006599999999999999,
                "pliCount": 0,
                "firCount": 0,
                "nackCount": 0,
                "qpSum": 253,
                "framesAssembledFromMultiplePackets": 2,
                "codec": "VP8"
            },
            "2": {
                "bandwidthMbit": 0.128728,
                "totalBytesReceived": 298159,
                "fps": 3,
                "decodeTime": 0.002002188679245283,
                "jitter": 0,
                "avgJitterBufferDelay": 0.0003707169811320754,
                "packetsReceived": 283,
                "packetsLost": 0,
                "framesDropped": 0,
                "framesDecoded": 53,
                "framesReceived": 53,
                "keyFramesDecoded": 1,
                "totalAssemblyTime": 0.0075109999999999994,
                "pliCount": 0,
                "firCount": 0,
                "nackCount": 0,
                "qpSum": 394,
                "framesAssembledFromMultiplePackets": 51,
                "codec": "VP8"
            },
            "3": {
                "bandwidthMbit": 0.142976,
                "totalBytesReceived": 315081,
                "fps": 3,
                "decodeTime": 0.002082905660377358,
                "jitter": 0,
                "avgJitterBufferDelay": 0.00035167924528301886,
                "packetsReceived": 316,
                "packetsLost": 0,
                "framesDropped": 0,
                "framesDecoded": 53,
                "framesReceived": 53,
                "keyFramesDecoded": 1,
                "totalAssemblyTime": 0.006548,
                "pliCount": 0,
                "firCount": 0,
                "nackCount": 0,
                "qpSum": 383,
                "framesAssembledFromMultiplePackets": 51,
                "codec": "VP8"
            }
        }
    }
    </details>

6. Also call the following func to open the stats overlay would show the stats for all displays 
   
    $ stream.showStatistics(true)
 
## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-4913

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: yes, this feature will be documented as part of multi display feature introduced in 1.31.0 release.