### PR TITLE
Extend rotation feature to support multi displays

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -284,8 +284,8 @@ class AnboxStream {
     this._gamepadManager = null;
     this._streamCanvas = null;
 
-    this._originalOrientation = null;
-    this._currentRotationDegrees = 0;
+    this._originalOrientationByDisplay = {};
+    this._rotationDegreesByDisplay = {};
 
     this._displayEventListeners = [];
 
@@ -1285,6 +1285,9 @@ class AnboxStream {
           },
         }
       : {};
+
+    this._originalOrientationByDisplay = {};
+    this._rotationDegreesByDisplay = {};
   }
 
   _stopStreaming() {
@@ -1482,29 +1485,42 @@ class AnboxStream {
   }
 
   /**
-   * Rotates the video element to a specific orientation or absolute degree.
+   * Rotates a display's video element to a specific orientation or absolute degree.
    * @param {number|string} orientation - The target orientation as an absolute degree (multiple of 90), or one of:
    *   'portrait', 'landscape', 'reverse-portrait', 'reverse-landscape'.
+   * @param {number} [displayId=0] - Index of the display to rotate. Each attached display
+   *   (see `attachDisplay`) can be rotated independently.
    *
-   * If a string is provided, the SDK maps it to degrees based on `this._originalOrientation`:
-   *   - when originalOrientation is 'portrait': portrait=0, landscape=90, reverse-portrait=180, reverse-landscape=270
-   *   - when originalOrientation is 'landscape': landscape=0, reverse-portrait=90, reverse-landscape=180, portrait=270
+   * If a string is provided, the SDK maps it to degrees based on the given display's original
+   * orientation:
+   *   - when the display's original orientation is 'portrait': portrait=0, landscape=90, reverse-portrait=180, reverse-landscape=270
+   *   - when the display's original orientation is 'landscape': landscape=0, reverse-portrait=90, reverse-landscape=180, portrait=270
    *
    * @note
    * 1. This value represents absolute degrees relative to the initial video orientation
-   * established when the session is first created regardless of whether the Android
-   * container is in portrait or landscape mode at startup, the initial degrees is always
-   * defined as 0. Since this is an absolute coordinate system, it is the
+   * established when the display's session is first created regardless of whether the
+   * Android container is in portrait or landscape mode at startup, the initial degrees is
+   * always defined as 0. Since this is an absolute coordinate system, it is the
    * caller's responsibility to provide the final target angle rather than a relative degree
    * from the current rotation.
    * 2. If the 'enableAccelerometer' option is enabled in the SDK configuration,
    * real-time sensor data from the client device will conflict with this function,
    * causing the rotation to be overridden or fail. Ensure manual rotation and
    * automatic accelerometer streaming are not used simultaneously.
+   * 3. Rotating any display sends a global accelerometer sensor event to the Android instance
+   * And sensor data is device-wide. This is independent from the local CSS rotation applied to
+   * the given displayId's video element. The touch input coordinates for each display are always
+   * remapped locally based on that display's own rotation state, so this is unaffected by which
+   * display the sensor event ends up applying to.
    * @returns {boolean} Returns true if the video element is rotated successfully, otherwise returns false.
    */
-  rotate(orientation) {
+  rotate(orientation, displayId = 0) {
     let degrees;
+
+    if (!(displayId in this._displayStates)) {
+      console.error(`Invalid display id given: ${displayId}`);
+      return false;
+    }
 
     if (typeof orientation === "string") {
       const orientationStrings = [
@@ -1519,15 +1535,16 @@ class AnboxStream {
         return false;
       }
 
+      const originalOrientation = this._originalOrientationByDisplay[displayId];
       let orientationToDegreesMap;
-      if (this._originalOrientation === "portrait") {
+      if (originalOrientation === "portrait") {
         orientationToDegreesMap = {
           portrait: 0,
           landscape: 90,
           "reverse-portrait": 180,
           "reverse-landscape": 270,
         };
-      } else if (this._originalOrientation === "landscape") {
+      } else if (originalOrientation === "landscape") {
         orientationToDegreesMap = {
           landscape: 0,
           "reverse-portrait": 90,
@@ -1535,9 +1552,7 @@ class AnboxStream {
           portrait: 270,
         };
       } else {
-        console.error(
-          `Invalid original orientation: ${this._originalOrientation}`,
-        );
+        console.error(`Invalid original orientation: ${originalOrientation}`);
         return false;
       }
 
@@ -1568,12 +1583,25 @@ class AnboxStream {
       return false;
     }
 
+    const videoId =
+      displayId === 0 ? this._videoID : `${this._videoID}-display-${displayId}`;
+    let visualElement;
+    if (displayId === 0 && this._options.experimental.upscaling.enabled) {
+      visualElement = document.getElementById(this._canvasID);
+    } else {
+      visualElement = document.getElementById(videoId);
+    }
+    if (!visualElement) {
+      console.error(`Cannot rotate: display ${displayId} is not attached.`);
+      return false;
+    }
+
     const normalized = ((degrees % 360) + 360) % 360;
-    this._currentRotationDegrees = normalized;
+    this._rotationDegreesByDisplay[displayId] = normalized;
 
     let accelData;
     const g = 9.81;
-    switch (this._currentRotationDegrees) {
+    switch (normalized) {
       case 90:
         accelData = { x: -g, y: 0, z: 0 };
         break;
@@ -1594,20 +1622,14 @@ class AnboxStream {
     };
     this._webrtcManager.sendControlMessage("sensor:event", data);
 
-    let visualElement;
-    if (this._options.experimental.upscaling.enabled) {
-      visualElement = document.getElementById(this._canvasID);
-    } else {
-      visualElement = document.getElementById(this._videoID);
-    }
-    visualElement.style.transform = `rotate(${this._currentRotationDegrees}deg)`;
+    visualElement.style.transform = `rotate(${normalized}deg)`;
     this._onResize();
 
     return true;
   }
 
-  getCurrentRotation() {
-    return this._currentRotationDegrees;
+  getCurrentRotation(displayId = 0) {
+    return this._rotationDegreesByDisplay[displayId] || 0;
   }
 
   _onResize() {
@@ -1655,7 +1677,8 @@ class AnboxStream {
       container.clientWidth - getPadding("left") - getPadding("right");
 
     // Handle rotation
-    switch (this._currentRotationDegrees) {
+    const rotationDegrees = this.getCurrentRotation(0);
+    switch (rotationDegrees) {
       case 0:
       case 180:
         break;
@@ -1688,7 +1711,7 @@ class AnboxStream {
     }
 
     let offsetTop;
-    switch (this._currentRotationDegrees) {
+    switch (rotationDegrees) {
       case 0:
       case 180:
         visualElement.style.height = playerHeight.toString() + "px";
@@ -1735,9 +1758,9 @@ class AnboxStream {
     }
 
     // Initialize basic orientation
-    if (this._originalOrientation === null) {
-      if (playerWidth > playerHeight) this._originalOrientation = "landscape";
-      else this._originalOrientation = "portrait";
+    if (this._originalOrientationByDisplay[0] === undefined) {
+      this._originalOrientationByDisplay[0] =
+        playerWidth > playerHeight ? "landscape" : "portrait";
     }
 
     // The visual offset is always derived from the same formula, no matter the orientation.
@@ -1754,28 +1777,46 @@ class AnboxStream {
     };
   }
 
-  // Compute dimensions for a single display's video element inside its container
+  // Compute dimensions for a display's video element inside its container
   // for multi-display mode.
   _computeMultiDisplayDimensions(video, container, displayId) {
     const cRect = container.getBoundingClientRect();
     const cellWidth = cRect.width;
     const cellHeight = cRect.height;
 
-    const videoWidth = video.videoWidth;
-    const videoHeight = video.videoHeight;
+    // When a display is rotated by 90 or 270 degrees, its on-screen aspect
+    // ratio is swapped compared to the native video, so the fit/scale
+    // computation below has to be based on the swapped dimensions.
+    const rotationDegrees = this.getCurrentRotation(displayId);
+    const isRotated = rotationDegrees === 90 || rotationDegrees === 270;
+    const videoWidth = isRotated ? video.videoHeight : video.videoWidth;
+    const videoHeight = isRotated ? video.videoWidth : video.videoHeight;
 
-    // Compute the largest size that fits the video aspect ratio inside the cell.
+    // Compute the largest size that fits the (possibly rotated) video aspect
+    // ratio inside the cell.
     const scale = Math.min(cellWidth / videoWidth, cellHeight / videoHeight);
     const renderedWidth = Math.round(videoWidth * scale);
     const renderedHeight = Math.round(videoHeight * scale);
-    const offsetLeft = Math.round((cellWidth - renderedWidth) / 2);
-    const offsetTop = Math.round((cellHeight - renderedHeight) / 2);
 
-    // Size and position the video element to exactly match the rendered content.
-    video.style.width = renderedWidth + "px";
-    video.style.height = renderedHeight + "px";
-    video.style.left = offsetLeft + "px";
-    video.style.top = offsetTop + "px";
+    if (isRotated) {
+      // Size the element with its un-rotated dimensions so that once the CSS
+      // `rotate()` transform is applied around its center, the resulting
+      // on-screen bounding box matches renderedWidth and renderedHeight.
+      const offsetLeft = Math.round((cellWidth - renderedHeight) / 2);
+      const offsetTop = Math.round((cellHeight - renderedWidth) / 2);
+      video.style.width = renderedHeight + "px";
+      video.style.height = renderedWidth + "px";
+      video.style.left = offsetLeft + "px";
+      video.style.top = offsetTop + "px";
+    } else {
+      const offsetLeft = Math.round((cellWidth - renderedWidth) / 2);
+      const offsetTop = Math.round((cellHeight - renderedHeight) / 2);
+      // Size and position the video element to exactly match the rendered content.
+      video.style.width = renderedWidth + "px";
+      video.style.height = renderedHeight + "px";
+      video.style.left = offsetLeft + "px";
+      video.style.top = offsetTop + "px";
+    }
 
     if (!(displayId in this._displayStates)) {
       this._displayStates[displayId] = {
@@ -1798,6 +1839,13 @@ class AnboxStream {
       playerOffsetLeft: 0,
       playerOffsetTop: 0,
     };
+
+    // Initialize this display's original orientation from its native video dimensions,
+    // so that string-based orientation values can be resolved for this display.
+    if (this._originalOrientationByDisplay[displayId] === undefined) {
+      this._originalOrientationByDisplay[displayId] =
+        video.videoWidth > video.videoHeight ? "landscape" : "portrait";
+    }
   }
 
   _triggerModifierEvent(event, key) {
@@ -1927,12 +1975,19 @@ class AnboxStream {
     const vRect = video.getBoundingClientRect();
     if (vRect.width === 0 || vRect.height === 0) return false;
 
+    // Swap width and height here too so scale/offset when a display is rotated
+    // 90/270 degrees to stay consistent with the rotated on-screen box.
+    const rotationDegrees = this.getCurrentRotation(displayId);
+    const isRotated = rotationDegrees === 90 || rotationDegrees === 270;
+    const videoWidth = isRotated ? video.videoHeight : video.videoWidth;
+    const videoHeight = isRotated ? video.videoWidth : video.videoHeight;
+
     const scale = Math.min(
-      vRect.width / video.videoWidth,
-      vRect.height / video.videoHeight,
+      vRect.width / videoWidth,
+      vRect.height / videoHeight,
     );
-    const renderedWidth = Math.round(video.videoWidth * scale);
-    const renderedHeight = Math.round(video.videoHeight * scale);
+    const renderedWidth = Math.round(videoWidth * scale);
+    const renderedHeight = Math.round(videoHeight * scale);
     const contentOffsetX = Math.round((vRect.width - renderedWidth) / 2);
     const contentOffsetY = Math.round((vRect.height - renderedHeight) / 2);
 
@@ -1951,8 +2006,8 @@ class AnboxStream {
     };
     if (!state.dimensions) {
       state.dimensions = {
-        videoWidth: video.videoWidth,
-        videoHeight: video.videoHeight,
+        videoWidth: videoWidth,
+        videoHeight: videoHeight,
         ...newValues,
       };
     } else {
@@ -2310,15 +2365,16 @@ class AnboxStream {
       throw newError("sdk is not ready yet", ANBOX_STREAM_SDK_ERROR_INTERNAL);
     }
 
-    if (this._currentRotationDegrees === 0) return { x: x, y: y };
+    const rotationDegrees = this.getCurrentRotation(displayId);
+    if (rotationDegrees === 0) return { x: x, y: y };
 
-    let radians = (Math.PI / 180) * this._currentRotationDegrees,
+    let radians = (Math.PI / 180) * rotationDegrees,
       cos = Math.cos(radians),
       sin = Math.sin(radians),
       nx = Math.round(cos * x + sin * y),
       ny = Math.round(cos * y - sin * x);
 
-    switch (this._currentRotationDegrees) {
+    switch (rotationDegrees) {
       case 90:
         ny += dim.playerWidth;
         break;

--- a/js/tests/unit/multi-display.test.js
+++ b/js/tests/unit/multi-display.test.js
@@ -539,3 +539,193 @@ describe("videoTrackAdded and videoTrackRemoved callbacks", () => {
     expect(added).toEqual([1, 2]);
   });
 });
+
+describe("rotation in multi-display mode", () => {
+  function setupRotatedDisplay0() {
+    const stream = makeStreamWithTarget("main-container");
+    stream._webrtcManager = {
+      _isControlChannelOpen: true,
+      sendControlMessage: jest.fn(),
+      stop: jest.fn(),
+    };
+
+    const video0 = document.createElement("video");
+    video0.id = stream._videoID;
+    video0.__defineGetter__("videoWidth", () => 500);
+    video0.__defineGetter__("videoHeight", () => 1000);
+    document.getElementById("main-container").appendChild(video0);
+    stream._onResize();
+
+    // Enter multi-display mode by attaching a second display.
+    const fakeStream = makeFakeStream();
+    stream._pendingVideoTracks[1] = fakeStream;
+    stream.attachDisplay(1, "cell-1");
+
+    // Display 0's container in legacy (targetElement) mode is main-container
+    // itself (800x600, per addContainer() defaults).
+    const cell0 = document.getElementById("main-container");
+
+    return { stream, video0, cell0 };
+  }
+
+  test("_computeMultiDisplayDimensions swaps the fit dimensions for display 0 when rotated", () => {
+    const { stream, video0, cell0 } = setupRotatedDisplay0();
+
+    expect(stream.rotate(90)).toEqual(true);
+
+    stream._computeMultiDisplayDimensions(video0, cell0, 0);
+    const dim = stream._displayStates[0].dimensions;
+
+    // Native video is 500x1000 (portrait); rotated 90deg it effectively
+    // becomes a 1000x500 (landscape) box, which fits the 800x600 cell as
+    // 800x400 to fit the original aspect ratio.
+    expect(dim.playerWidth).toEqual(800);
+    expect(dim.playerHeight).toEqual(400);
+
+    // The element itself must be sized with the pre-transform dimensions
+    // so that after rotate 90deg, the on-screen box matches player size.
+    expect(video0.style.width).toEqual("400px");
+    expect(video0.style.height).toEqual("800px");
+  });
+
+  test("touch coordinates for a rotated display 0 match single-display behaviour", () => {
+    const single = makeStreamWithTarget("main-container");
+    single._webrtcManager = {
+      _isControlChannelOpen: true,
+      sendControlMessage: jest.fn(() => true),
+      stop: jest.fn(),
+    };
+    const singleVideo = document.createElement("video");
+    singleVideo.id = single._videoID;
+    singleVideo.__defineGetter__("videoWidth", () => 500);
+    singleVideo.__defineGetter__("videoHeight", () => 1000);
+    document.getElementById("main-container").appendChild(singleVideo);
+    single._onResize();
+    expect(single.rotate(90)).toEqual(true);
+    single._registerInputHandlers(0, document.getElementById("main-container"));
+
+    document.getElementById("main-container").dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerType: "touch",
+        clientX: 0,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 1,
+      }),
+    );
+    const singleCall = single._webrtcManager.sendControlMessage.mock.calls.find(
+      (c) => c[0] === "input::touch-start",
+    );
+    expect(singleCall).toBeDefined();
+
+    document.body.innerHTML = "";
+
+    // Multi-display case: a second display attached to test multi-display mode.
+    const {
+      stream: multi,
+      video0,
+      cell0,
+    } = (() => {
+      const containerEl = document.createElement("div");
+      containerEl.id = "main-container";
+      containerEl.__defineGetter__("clientWidth", () => 800);
+      containerEl.__defineGetter__("clientHeight", () => 600);
+      containerEl.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 800,
+        height: 600,
+        right: 800,
+        bottom: 600,
+      });
+      document.body.appendChild(containerEl);
+
+      const cell1 = document.createElement("div");
+      cell1.id = "cell-1";
+      document.body.appendChild(cell1);
+
+      return setupRotatedDisplay0();
+    })();
+
+    expect(multi.rotate(90)).toEqual(true);
+    multi._registerInputHandlers(0, cell0);
+
+    // Simulate the actual on-screen bounding box after rotating 90deg.
+    video0.getBoundingClientRect = () => ({
+      left: 0,
+      top: 100,
+      width: 800,
+      height: 400,
+      right: 800,
+      bottom: 500,
+    });
+
+    cell0.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        pointerType: "touch",
+        clientX: 0,
+        clientY: 100,
+        isPrimary: true,
+        pointerId: 1,
+      }),
+    );
+    const multiCall = multi._webrtcManager.sendControlMessage.mock.calls.find(
+      (c) => c[0] === "input::touch-start",
+    );
+    expect(multiCall).toBeDefined();
+
+    // Both modes must map the exact same on-screen click to the exact same
+    // remote coordinates.
+    expect(multiCall[1].x).toBeCloseTo(singleCall[1].x, 0);
+    expect(multiCall[1].y).toBeCloseTo(singleCall[1].y, 0);
+  });
+
+  test("each attached display can be rotated independently", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._webrtcManager = {
+      _isControlChannelOpen: true,
+      sendControlMessage: jest.fn(),
+      stop: jest.fn(),
+    };
+
+    const video0 = document.createElement("video");
+    video0.id = stream._videoID;
+    video0.__defineGetter__("videoWidth", () => 500);
+    video0.__defineGetter__("videoHeight", () => 1000);
+    document.getElementById("main-container").appendChild(video0);
+    stream._onResize();
+
+    stream._pendingVideoTracks[1] = makeFakeStream();
+    stream.attachDisplay(1, "cell-1");
+    const video1 = document.getElementById(`${stream._videoID}-display-1`);
+    video1.__defineGetter__("videoWidth", () => 400);
+    video1.__defineGetter__("videoHeight", () => 300);
+
+    // The display 0 must stay unrotated when rotating display 1 only;
+    expect(stream.rotate(90, 1)).toEqual(true);
+    expect(video1.style.transform).toEqual("rotate(90deg)");
+    expect(video0.style.transform).not.toEqual("rotate(90deg)");
+    expect(stream.getCurrentRotation(0)).toEqual(0);
+    expect(stream.getCurrentRotation(1)).toEqual(90);
+
+    // The display 1 must be unaffected when when rotating display 0 only;
+    expect(stream.rotate(180, 0)).toEqual(true);
+    expect(video0.style.transform).toEqual("rotate(180deg)");
+    expect(stream.getCurrentRotation(0)).toEqual(180);
+    expect(stream.getCurrentRotation(1)).toEqual(90);
+  });
+
+  test("rotate() fails for a display id that is not attached", () => {
+    const stream = makeStreamWithTarget("main-container");
+    stream._webrtcManager = {
+      _isControlChannelOpen: true,
+      sendControlMessage: jest.fn(),
+      stop: jest.fn(),
+    };
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(stream.rotate(90, 5)).toEqual(false);
+
+    errSpy.mockRestore();
+  });
+});

--- a/js/tests/unit/sdk.test.js
+++ b/js/tests/unit/sdk.test.js
@@ -326,12 +326,12 @@ test("rotate supports legacy orientation strings", () => {
   stream._onResize();
 
   // null original orientation should not work for string-based rotations
-  stream._originalOrientation = null;
+  stream._originalOrientationByDisplay[0] = null;
   expect(stream.rotate("portrait")).toEqual(false);
   expect(errSpy).toHaveBeenCalledWith("Invalid original orientation: null");
 
   // portrait origin mapping
-  stream._originalOrientation = "portrait";
+  stream._originalOrientationByDisplay[0] = "portrait";
 
   expect(stream.rotate("landscape")).toEqual(true);
   expect(stream.getCurrentRotation()).toEqual(90);
@@ -382,7 +382,7 @@ test("rotate supports legacy orientation strings", () => {
   );
 
   // landscape origin mapping
-  stream._originalOrientation = "landscape";
+  stream._originalOrientationByDisplay[0] = "landscape";
 
   expect(stream.rotate("reverse-portrait")).toEqual(true);
   expect(stream.getCurrentRotation()).toEqual(90);


### PR DESCRIPTION
## Done

This change extends the rotation API to support screen rotation
per display in multi-display mode. It mainly replaces the global
orientation state with per-display maps, updates dimension and
coordinate calculations to respect per-display rotation.
    
NOTE: this change maintains full backward compatibility for
single-display usage, where the `targetElement` is in used when
initializing anbox stream.

## QA

1. Import the JS SDK into a stream client
2. Launch an instance with multi displays form euphotic image:
   $ amc launch resolute:android16-cf:amd64 --enable-streaming --devmode -c 4 -m 8GB --name test-multi-display
      --display=width=1280,height=720,fps=60
      --display=width=480,height=640,dpi=120
      --display=width=800,height=600,fps=30
3. Once streaming the up and running, 
    - rotate the primary display via
       stream.rotate(90); or  stream.rotate(90, 0);
   - rotate the external screen 
       stream.rotate(90, 1)
    
    Verify that the video element takes up the whole space of the video container while respecting the aspect ratio, and ensure touch input works as intended with no offset. 
    // NOTE: Up to now, acceleration-data-based screen rotation only acts on the primary display.

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: yes, this feature will be documented as part of multi display feature introduced in 1.31.0 release.