### PR TITLE
Support full screen per display in multi-display mode

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -313,7 +313,7 @@ class AnboxStream {
    * Connect a new instance for the configured application or attach to an existing one
    */
   async connect() {
-    if (this._options.fullScreen) this._requestFullscreen();
+    if (this._options.fullScreen) this.requestFullscreen(0);
 
     let session = {};
     try {
@@ -516,19 +516,23 @@ class AnboxStream {
   }
 
   /**
-   * Toggle fullscreen for the streamed video.
+   * Toggle fullscreen for the streamed video of a given display.
    *
    * IMPORTANT: fullscreen can only be toggled following a user input.
    * If you call this method when your page loads, it will not work.
+   *
+   * @param {number} [displayId=0] Index of the display to show in full screen.
    */
-  _requestFullscreen() {
+  requestFullscreen(displayId = 0) {
     if (!document.fullscreenEnabled) {
       console.error("fullscreen not supported");
       return;
     }
+    const videoID =
+      displayId === 0 ? this._videoID : `${this._videoID}-display-${displayId}`;
     const fullscreenExited = () => {
       if (document.fullscreenElement === null) {
-        const video = document.getElementById(this._videoID);
+        const video = document.getElementById(videoID);
         if (video) {
           video.style.width = null;
           video.style.height = null;
@@ -544,7 +548,15 @@ class AnboxStream {
     // https://bugs.chromium.org/p/chromium/issues/detail?id=462164
     // To work around it we put the outer container in fullscreen and scale the video
     // to fit it. When exiting fullscreen we undo style changes done to the video element
-    const videoContainer = document.getElementById(this._containerIDs[0]);
+    const videoContainer = document.getElementById(
+      this._containerIDs[displayId],
+    );
+    if (!videoContainer) {
+      console.error(
+        `[AnboxStream] requestFullscreen(${displayId}): container not found for this display.`,
+      );
+      return;
+    }
     if (videoContainer.requestFullscreen) {
       videoContainer.requestFullscreen().catch((err) => {
         console.log(


### PR DESCRIPTION
## Done

This change evolves `_requestFullscreen()` as a public API
`requestFullscreen(displayId = 0)` to support per-display fullscreen
in multi-display mode.
NOTE: it defaults to `displayId = 0` for backward compatibility.

## QA

1. Import the JS SDK into a stream client
2. Launch an instance with multi displays form euphotic image:
   $ amc launch resolute:android16-cf:amd64 --enable-streaming --devmode -c 4 -m 8GB --name test-multi-display
      --display=width=1280,height=720,fps=60
      --display=width=480,height=640,dpi=120
      --display=width=800,height=600,fps=30
3. Once streaming the up and running, 
    - request full screen for the primary display via
       stream.requestFullscreen(); or  stream.requestFullscreen(0);
   - request full screen for an external screen 
       stream.requestFullscreen(1)
    
## JIRA / Launchpad bug

Fixes https://warthogs.atlassian.net/browse/AC-4915

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
A: yes, this feature will be documented as part of multi display feature introduced in 1.31.0 release.