### PR TITLE
Add null guard for video and audio tracks

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1163,6 +1163,10 @@ class AnboxStream {
         }
       } else {
         const video = document.getElementById(this._videoID);
+        if (!video) {
+          console.warn("Video element not found, ignoring stream track");
+          return;
+        }
         video.srcObject = videoSource;
 
         // Expliclity to call play() method to the video element if it's hidden,
@@ -1174,6 +1178,10 @@ class AnboxStream {
 
     if (this._options.stream.audio && this._options.devices.speaker) {
       const audio = document.getElementById(this._audioID);
+      if (!audio) {
+        console.warn("Audio element not found, ignoring stream track");
+        return;
+      }
       audio.srcObject = audioSource;
     }
 


### PR DESCRIPTION
## Done

In case we get a ready stream, and then the video or audio track disappears (crash on the producer side for instance), we would get a crash in the JS side too. Adding a null check ensures we don't get a crash and can handle errors more gracefully.

## QA

Hard to QA, because it requires a problem on the producer side.

## JIRA / Launchpad bug

Contributes to [AC-4954](https://warthogs.atlassian.net/browse/AC-4954)

## Documentation

N/A

[AC-4954]: https://warthogs.atlassian.net/browse/AC-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ