### PR TITLE
Add listener on resize for legacy single display case

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1117,6 +1117,7 @@ class AnboxStream {
           this._streamCanvases[0].startRendering();
         }
       };
+      video.addEventListener("resize", this._onResize);
       mediaContainer.appendChild(video);
 
       pointerLockElement = video;


### PR DESCRIPTION
## Done

Ensures we get properly notified in case of resizes in the single display case, to make sure we get the proper set of coordinates.

## QA

Test resize on a running stream.

## JIRA / Launchpad bug

Contributes to [AC-4954](https://warthogs.atlassian.net/browse/AC-4954)

## Documentation

N/A

[AC-4954]: https://warthogs.atlassian.net/browse/AC-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ