### PR TITLE
fix: added small session creation checks

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -5091,7 +5091,12 @@ class AnboxStreamGatewayConnector {
       );
 
     const response = await rawResp.json();
-    if (response === undefined || response.status !== "success")
+    if (this._nullOrUndef(response))
+      throw newError(
+        "failed to create session",
+        ANBOX_STREAM_SDK_ERROR_SESSION_FAILED,
+      );
+    if (response.status !== "success")
       throw newError(response.error, ANBOX_STREAM_SDK_ERROR_SESSION_FAILED);
 
     return {
@@ -5127,7 +5132,12 @@ class AnboxStreamGatewayConnector {
       );
 
     let response = await rawJoinResp.json();
-    if (response === undefined || response.status !== "success")
+    if (this._nullOrUndef(response))
+      throw newError(
+        "Session does not exist anymore",
+        ANBOX_STREAM_SDK_ERROR_SESSION_FAILED,
+      );
+    if (response.status !== "success")
       throw newError(response.error, ANBOX_STREAM_SDK_ERROR_SESSION_FAILED);
 
     return {


### PR DESCRIPTION
## Done

Some Error handling improvements:

* Updated the session creation logic to throw a clear error if the response is undefined or null, before checking the response status (`js/anbox-stream-sdk.js`, `AnboxStreamGatewayConnector`).
* Updated the session join logic to throw a specific error message ("Session does not exist anymore") if the response is undefined or null, improving clarity for this failure mode (`js/anbox-stream-sdk.js`, `AnboxStreamGatewayConnector`).

## QA
NA

## JIRA / Launchpad bug
NA

## Fixes
NA

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?
No