### PR TITLE
Remove useless functions and fix an undefined callback

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -1205,48 +1205,6 @@ class AnboxStream {
     this._options.callbacks.videoTrackAdded(displayId);
   }
 
-  _activateMultiDisplayGrid(container) {
-    this._multiDisplayActive = true;
-
-    // Wrap the primary video in a dedicated cell div so it becomes one
-    // equal grid item alongside the additional display cells.
-    const cell = document.createElement("div");
-    cell.id = `${this._videoID}-cell-0`;
-    cell.className = "anbox-stream-cell";
-    cell.style.position = "relative";
-    cell.style.overflow = "hidden";
-
-    const primaryVideo = document.getElementById(this._videoID);
-    if (primaryVideo) {
-      // Make the primary video fill its new cell via absolute positioning,
-      // consistent with how secondary videos are rendered.
-      primaryVideo.style.position = "absolute";
-      primaryVideo.style.inset = "0";
-      primaryVideo.style.width = "100%";
-      primaryVideo.style.height = "100%";
-      primaryVideo.style.objectFit = "contain";
-      primaryVideo.style.top = "";
-      primaryVideo.style.left = "";
-      primaryVideo.style.maxWidth = "";
-      primaryVideo.style.maxHeight = "";
-      cell.appendChild(primaryVideo);
-    }
-    container.insertBefore(cell, container.firstChild);
-
-    // Move the display 0 input zone from the outer container to cell-0 so
-    // pointer events are scoped to the actual video area.
-    this._unregisterInputHandlers(0);
-    this._containerIDs[0] = cell.id;
-    this._registerInputHandlers(0, cell);
-
-    container.style.display = "grid";
-    container.style.width = "100%";
-    container.style.height = "100%";
-    container.style.gap = "0";
-    container.style.overflow = "hidden";
-    container.style.boxSizing = "border-box";
-  }
-
   _createExtraVideoElement(id, stream) {
     const video = document.createElement("video");
     video.id = id;
@@ -1294,14 +1252,6 @@ class AnboxStream {
 
     this._streamCanvases[displayId] = streamCanvas;
     return streamCanvas.initialize();
-  }
-
-  _updateGridColumns(container) {
-    const count = container.querySelectorAll(".anbox-stream-cell").length;
-    const cols = Math.ceil(Math.sqrt(count));
-    const rows = Math.ceil(count / cols);
-    container.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-    container.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
   }
 
   _removeMedia() {

--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -216,7 +216,12 @@ class AnboxStream {
       preferredVideoDecoderCodecs: this._options.video.preferred_decoder_codecs,
     });
     this._webrtcManager.onReady(this._webrtcReady.bind(this));
-    this._webrtcManager.onExtraVideoTrack(this._onExtraVideoTrack.bind(this));
+    this._webrtcManager.onExtraVideoTrackAdded(
+      this._onExtraVideoTrackAdded.bind(this),
+    );
+    this._webrtcManager.onExtraVideoTrackEnded(
+      this._onExtraVideoTrackEnded.bind(this),
+    );
     this._webrtcManager.onError((err) => {
       this._stopStreamingOnError(err.message, err.cause.code);
     });
@@ -1193,7 +1198,7 @@ class AnboxStream {
     }
   }
 
-  _onExtraVideoTrack(displayId, stream) {
+  _onExtraVideoTrackAdded(displayId, stream) {
     const videoId = `${this._videoID}-display-${displayId}`;
     if (document.getElementById(videoId)) {
       document.getElementById(videoId).srcObject = stream;
@@ -1203,6 +1208,10 @@ class AnboxStream {
     this._pendingReadyCount++;
     this._pendingVideoTracks[displayId] = stream;
     this._options.callbacks.videoTrackAdded(displayId);
+  }
+
+  _onExtraVideoTrackEnded(displayId) {
+    this._options.callbacks.videoTrackRemoved(displayId);
   }
 
   _createExtraVideoElement(id, stream) {
@@ -3036,7 +3045,9 @@ class AnboxWebRTCManager {
     this._onReady = (videoStream, audioStream) => {};
     this._onClose = () => {};
     // eslint-disable-next-line no-unused-vars
-    this._onExtraVideoTrack = (displayId, stream) => {};
+    this._onExtraVideoTrackAdded = (displayId, stream) => {};
+    // eslint-disable-next-line no-unused-vars
+    this._onExtraVideoTrackEnded = (displayId) => {};
     this._onMicRequested = () => false;
     this._onCameraRequested = () => false;
     // eslint-disable-next-line no-unused-vars
@@ -3073,19 +3084,29 @@ class AnboxWebRTCManager {
   }
 
   /**
-   * @callback onExtraVideoTrack
+   * @callback onExtraVideoTrackAdded
    * @param displayId {number} zero-based display id derived from the server-assigned
    *   track name.
    * @param stream {MediaStream} Stream to attach to the extra video element
    */
   /**
    * Called when an additional video track is received.
-   * The display id is parsed from the server-assigned track name and is
-   * stable even when displays are added or removed dynamically.
-   * @param callback {onExtraVideoTrack}
+   * @param callback {onExtraVideoTrackAdded}
    */
-  onExtraVideoTrack(callback) {
-    this._onExtraVideoTrack = callback;
+  onExtraVideoTrackAdded(callback) {
+    this._onExtraVideoTrackAdded = callback;
+  }
+
+  /**
+   * @callback onExtraVideoTrackEnded
+   * @param displayId {number} zero-based display id whose track just ended.
+   */
+  /**
+   * Called when an additional display's video track ends,
+   * @param callback {onExtraVideoTrackEnded}
+   */
+  onExtraVideoTrackEnded(callback) {
+    this._onExtraVideoTrackEnded = callback;
   }
 
   /**
@@ -3884,9 +3905,8 @@ class AnboxWebRTCManager {
         event.track.onended = this._onClose;
       } else {
         // Notify AnboxStream to attach the new video track to a video container.
-        this._onExtraVideoTrack(displayId, singleTrackStream);
-        event.track.onended = () =>
-          this._options.callbacks.videoTrackRemoved(displayId);
+        this._onExtraVideoTrackAdded(displayId, singleTrackStream);
+        event.track.onended = () => this._onExtraVideoTrackEnded(displayId);
       }
     } else if (kind === "audio") {
       this._audioStream = event.streams[0];

--- a/js/tests/unit/multi-display.test.js
+++ b/js/tests/unit/multi-display.test.js
@@ -140,13 +140,13 @@ describe("_checkReady", () => {
   });
 });
 
-describe("_onExtraVideoTrack", () => {
+describe("_onExtraVideoTrackAdded", () => {
   test("increments pendingReadyCount and stores stream in pendingVideoTracks", () => {
     const stream = makeStreamWithTarget();
     const fakeStream = makeFakeStream();
 
     expect(stream._pendingReadyCount).toBe(0);
-    stream._onExtraVideoTrack(1, fakeStream);
+    stream._onExtraVideoTrackAdded(1, fakeStream);
 
     expect(stream._pendingReadyCount).toBe(1);
     expect(stream._pendingVideoTracks[1]).toBe(fakeStream);
@@ -159,7 +159,7 @@ describe("_onExtraVideoTrack", () => {
       callbacks: { videoTrackAdded },
     });
 
-    stream._onExtraVideoTrack(2, makeFakeStream());
+    stream._onExtraVideoTrackAdded(2, makeFakeStream());
 
     expect(videoTrackAdded).toHaveBeenCalledWith(2);
   });
@@ -167,9 +167,9 @@ describe("_onExtraVideoTrack", () => {
   test("increments pendingReadyCount for each new extra track", () => {
     const stream = makeStreamWithTarget();
 
-    stream._onExtraVideoTrack(1, makeFakeStream());
-    stream._onExtraVideoTrack(2, makeFakeStream());
-    stream._onExtraVideoTrack(3, makeFakeStream());
+    stream._onExtraVideoTrackAdded(1, makeFakeStream());
+    stream._onExtraVideoTrackAdded(2, makeFakeStream());
+    stream._onExtraVideoTrackAdded(3, makeFakeStream());
 
     expect(stream._pendingReadyCount).toBe(3);
     expect(stream._pendingVideoTracks[1]).toBeDefined();
@@ -187,12 +187,42 @@ describe("_onExtraVideoTrack", () => {
     videoEl.id = `${stream._videoID}-display-1`;
     document.body.appendChild(videoEl);
 
-    stream._onExtraVideoTrack(1, fakeStream1);
+    stream._onExtraVideoTrackAdded(1, fakeStream1);
     // pendingReadyCount should NOT increment since video already exists.
     expect(stream._pendingReadyCount).toBe(0);
 
-    stream._onExtraVideoTrack(1, fakeStream2);
+    stream._onExtraVideoTrackAdded(1, fakeStream2);
     expect(videoEl.srcObject).toBe(fakeStream2);
+  });
+});
+
+describe("_onExtraVideoTrackEnded", () => {
+  test("fires videoTrackRemoved callback with the correct displayId", () => {
+    const videoTrackRemoved = jest.fn();
+    const stream = makeStream({
+      targetElement: "main-container",
+      callbacks: { videoTrackRemoved },
+    });
+
+    stream._onExtraVideoTrackEnded(2);
+
+    expect(videoTrackRemoved).toHaveBeenCalledTimes(1);
+    expect(videoTrackRemoved).toHaveBeenCalledWith(2);
+  });
+
+  test("fires videoTrackRemoved independently for each displayId", () => {
+    const videoTrackRemoved = jest.fn();
+    const stream = makeStream({
+      targetElement: "main-container",
+      callbacks: { videoTrackRemoved },
+    });
+
+    stream._onExtraVideoTrackEnded(1);
+    stream._onExtraVideoTrackEnded(3);
+
+    expect(videoTrackRemoved).toHaveBeenCalledTimes(2);
+    expect(videoTrackRemoved).toHaveBeenNthCalledWith(1, 1);
+    expect(videoTrackRemoved).toHaveBeenNthCalledWith(2, 3);
   });
 });
 
@@ -588,8 +618,8 @@ describe("videoTrackAdded and videoTrackRemoved callbacks", () => {
       callbacks: { videoTrackAdded: (i) => added.push(i) },
     });
 
-    stream._onExtraVideoTrack(1, makeFakeStream());
-    stream._onExtraVideoTrack(2, makeFakeStream());
+    stream._onExtraVideoTrackAdded(1, makeFakeStream());
+    stream._onExtraVideoTrackAdded(2, makeFakeStream());
 
     expect(added).toEqual([1, 2]);
   });

--- a/js/tests/unit/multi-display.test.js
+++ b/js/tests/unit/multi-display.test.js
@@ -214,50 +214,6 @@ describe("_createExtraVideoElement", () => {
   });
 });
 
-describe("_updateGridColumns", () => {
-  function makeGrid(cellCount) {
-    const container = document.createElement("div");
-    for (let i = 0; i < cellCount; i++) {
-      const cell = document.createElement("div");
-      cell.className = "anbox-stream-cell";
-      container.appendChild(cell);
-    }
-    return container;
-  }
-
-  test("1 display: 1 column, 1 row", () => {
-    const stream = makeStreamWithTarget();
-    const container = makeGrid(1);
-    stream._updateGridColumns(container);
-    expect(container.style.gridTemplateColumns).toBe("repeat(1, 1fr)");
-    expect(container.style.gridTemplateRows).toBe("repeat(1, 1fr)");
-  });
-
-  test("2 displays: 2 columns, 1 row", () => {
-    const stream = makeStreamWithTarget();
-    const container = makeGrid(2);
-    stream._updateGridColumns(container);
-    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
-    expect(container.style.gridTemplateRows).toBe("repeat(1, 1fr)");
-  });
-
-  test("3 displays: 2 columns, 2 rows", () => {
-    const stream = makeStreamWithTarget();
-    const container = makeGrid(3);
-    stream._updateGridColumns(container);
-    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
-    expect(container.style.gridTemplateRows).toBe("repeat(2, 1fr)");
-  });
-
-  test("4 displays: 2 columns, 2 rows", () => {
-    const stream = makeStreamWithTarget();
-    const container = makeGrid(4);
-    stream._updateGridColumns(container);
-    expect(container.style.gridTemplateColumns).toBe("repeat(2, 1fr)");
-    expect(container.style.gridTemplateRows).toBe("repeat(2, 1fr)");
-  });
-});
-
 describe("attachDisplay (legacy mode)", () => {
   test("attachDisplay(0) is a no-op when targetElement is set", () => {
     const stream = makeStreamWithTarget("main-container");


### PR DESCRIPTION
## Done

1.  Both functions _activateMultiDisplayGrid() and _updateGridColumns()
    are only defined but never called anywhere. Due to the fact that we
    switch to using attachDisplay() function and doesn't rely on this
    grid logic at all and leaves the layout to the caller instead.
    So as private functions, we can safely remove them for cleaner code
    base.

2.When improving the integratin tests for multi display for anbox repo,
    the following error came up:
```
      2026-09-03 03:59:21 INFO [browser console:log] [SDK DEBUG] track.onended fired for displayId=1: this._options=undefined
      2026-09-03 03:59:21 ERROR [browser pageerror] TypeError: Cannot read properties of undefined (reading 'callbacks')
          at event.track.onended (http://127.0.0.1:38943/static/anbox-stream-sdk.js:3970:25)
      2026-09-03 03:59:21 INFO [browser console:log] [SDK DEBUG] track.onended fired for displayId=2: this._options=undefined
      2026-09-03 03:59:21 ERROR [browser pageerror] TypeError: Cannot read properties of undefined (reading 'callbacks')
          at event.track.onended (http://127.0.0.1:38943/static/anbox-stream-sdk.js:3970:25)
``` 
    so AnboxWebRTCManager attempted to access this._options.callbacks
    directly when a video track's onended event fired, causing a TypeError
    as _options is not defined on AnboxWebRTCManager.
    
    This change introduces onExtraVideoTrackEnded to symmetry
    onExtraVideoTrackAdded (renamed from onExtraVideoTrack), routing
    track removal events back to AnboxStream to safely invoke
    videoTrackRemoved(displayId)

## QA

Ensure no breakage introduced and all tests should pass

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?

A: no, it doesn't