### PR TITLE
Stop client from creating its own control channel

### DIFF
--- a/js/anbox-stream-sdk.js
+++ b/js/anbox-stream-sdk.js
@@ -3586,6 +3586,7 @@ class AnboxWebRTCManager {
     this._pc.oniceconnectionstatechange =
       this._onRtcIceConnectionStateChange.bind(this);
     this._pc.onicecandidate = this._onRtcIceCandidate.bind(this);
+    this._pc.ondatachannel = this._onRtcDataChannel.bind(this);
 
     this._createControlChannel();
 
@@ -3639,7 +3640,14 @@ class AnboxWebRTCManager {
   }
 
   _createControlChannel() {
-    this._controlChan = this._pc.createDataChannel("control");
+    // With API version >= 2 the server is the SDP offerer and already
+    // creates the "control" data channel before generating its offer.
+    if (this._apiVersionInUse < 2)
+      this._wireControlChannel(this._pc.createDataChannel("control"));
+  }
+
+  _wireControlChannel(channel) {
+    this._controlChan = channel;
     this._controlChan.onopen = this._onControlChannelOpen;
     this._controlChan.onmessage = this._onControlMessageReceived.bind(this);
     this._controlChan.onerror = (err) => {
@@ -3659,16 +3667,29 @@ class AnboxWebRTCManager {
   }
 
   _createDataChannels() {
+    // Unlike control channels, oob data channels are always initiated locally
+    // by the client. The server waits for the client channel to arrive before
+    // it starts forwarding data.
     Object.keys(this._dataChannels).forEach((name) => {
-      let channel = this._pc.createDataChannel(name);
-      channel.onmessage = (event) =>
-        this._dataChannels[name].callbacks.message(event.data);
-      channel.onerror = (err) =>
-        this._dataChannels[name].callbacks.error(err.error.message);
-      channel.onclose = () => this._dataChannels[name].callbacks.close();
-      channel.onopen = () => this._dataChannels[name].callbacks.open();
-      this._dataChans[name] = channel;
+      this._wireDataChannel(name, this._pc.createDataChannel(name));
     });
+  }
+
+  _wireDataChannel(name, channel) {
+    channel.onmessage = (event) =>
+      this._dataChannels[name].callbacks.message(event.data);
+    channel.onerror = (err) =>
+      this._dataChannels[name].callbacks.error(err.error.message);
+    channel.onclose = () => this._dataChannels[name].callbacks.close();
+    channel.onopen = () => this._dataChannels[name].callbacks.open();
+    this._dataChans[name] = channel;
+  }
+
+  _onRtcDataChannel(event) {
+    // Only the "control" data channel is expected here as with API version
+    // >= 2. See _createControlChannel() for details.
+    const channel = event.channel;
+    if (channel.label === "control") this._wireControlChannel(channel);
   }
 
   _onWsError(err) {

--- a/js/tests/unit/callbacks.test.js
+++ b/js/tests/unit/callbacks.test.js
@@ -241,32 +241,34 @@ test("custom message callback is called", (done) => {
     },
   };
 
-  let chans = [];
-  const pcMock = {
-    createDataChannel: () => {
-      let chan = {
-        onmessage: () => {},
-        onerror: {},
-        onclose: {},
-        onopen: {},
-      };
-
-      chans.push(chan);
-      return chan;
-    },
+  const fooChan = {
+    label: "foo",
+    onmessage: () => {},
+    onerror: {},
+    onclose: {},
+    onopen: {},
+  };
+  const barChan = {
+    label: "bar",
+    onmessage: () => {},
+    onerror: {},
+    onclose: {},
+    onopen: {},
   };
 
   const stream = new AnboxStream(sdkOptions);
-  stream._webrtcManager._pc = pcMock;
-  stream._webrtcManager._createDataChannels();
+  // Custom (oob) data channels are always created locally by the client;
+  // this directly exercises the wiring _createDataChannels() would set up.
+  stream._webrtcManager._wireDataChannel("foo", fooChan);
+  stream._webrtcManager._wireDataChannel("bar", barChan);
 
   // For `bar` data channel
-  chans[1].onopen();
+  barChan.onopen();
   expect(sdkOptions.dataChannels["bar"].callbacks.open).toHaveBeenCalledTimes(
     1,
   );
 
-  chans[1].onclose();
+  barChan.onclose();
   expect(sdkOptions.dataChannels["bar"].callbacks.close).toHaveBeenCalledTimes(
     1,
   );
@@ -274,18 +276,18 @@ test("custom message callback is called", (done) => {
   let error = {
     error: { message: "data transfer interrupted" },
   };
-  chans[1].onerror(error);
+  barChan.onerror(error);
 
   let event = { data: "bar_text" };
-  chans[1].onmessage(event);
+  barChan.onmessage(event);
 
   // For `foo` data channel
-  chans[0].onopen();
+  fooChan.onopen();
   expect(sdkOptions.dataChannels["foo"].callbacks.open).toHaveBeenCalledTimes(
     1,
   );
 
-  chans[0].onclose();
+  fooChan.onclose();
   expect(sdkOptions.dataChannels["foo"].callbacks.close).toHaveBeenCalledTimes(
     1,
   );
@@ -293,10 +295,10 @@ test("custom message callback is called", (done) => {
   error = {
     error: { message: "data channel is closed" },
   };
-  chans[0].onerror(error);
+  fooChan.onerror(error);
 
   event = { data: "foo_text" };
-  chans[0].onmessage(event);
+  fooChan.onmessage(event);
 });
 
 test("do not log control message data when debug is disabled", () => {


### PR DESCRIPTION
## Done

For API version >= 2 the server acts as the SDP offerer and already creates the "control" data channel in configure_peer_connection() before generating its offer. The client SDK was independently calling createDataChannel("control") too, resulting in two distinct control channels that only happened to share a label. The server's PeerConnection::OnDataChannel() matches channels by label and would overwrite its tracked channel and re-register the existing observer onto the new channel, causing resume_from_last_state() (and other control-channel-open handling) to fire twice per connection.

Hence stop client from creating its own control channel when API version >=2.

NOTE:
1. unlike the control channel, oob data channels are always created locally by the client. The server relies on seeing the client's channel arrive to know when to start forwarding data for it. So this is intentionally left unchanged.
2. this is a client-only change and does not requires server-side changes and works against any server version.

## QA

All tests should be pass.
This change should be fully backward & forward compatibility.
Meaning nothing would break for all old images prior to 1.31, or new images.

## JIRA / Launchpad bug

Fixes #

## Documentation

Does this impact the team's internal or public documentation? If yes, has the relevant documentation been updated?